### PR TITLE
fixing image tag and app version

### DIFF
--- a/pihole/Chart.yaml
+++ b/pihole/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
-appVersion: "1.0"
+appVersion: "4.3.1-4"
 description: Installs pihole in kubernetes 
 name: pihole
-version: 0.1.0
+version: 0.1.1
 maintainers:
   - name: Christian Erhardt
     email: christian.erhardt@mojo2k.de

--- a/pihole/values.yaml
+++ b/pihole/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 image:
   repository: "pihole/pihole"
-  tag: 4.3.1-4_amd64 
+  tag: 4.3.1-4
   pullPolicy: IfNotPresent
 
 serviceTCP:


### PR DESCRIPTION
* Setting the chart 'appimage' to the current pihole version
* Specifying the multi-arch image tag instead of opinionated amd64-only tagged image.  See [the docker hub tag info](https://hub.docker.com/r/pihole/pihole/tags/) for more details.