### PR TITLE
fix: Adjust readiness/liveness probe indentation

### DIFF
--- a/pihole/Chart.yaml
+++ b/pihole/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: "4.3.2-1"
 description: Installs pihole in kubernetes 
 name: pihole
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: Christian Erhardt
     email: christian.erhardt@mojo2k.de

--- a/pihole/templates/deployment.yaml
+++ b/pihole/templates/deployment.yaml
@@ -88,13 +88,13 @@ spec:
           - containerPort: 67
             name: client-udp
             protocol: UDP
-            livenessProbe:
+          livenessProbe:
               httpGet:
                 path: /admin.index.php
                 port: http
               initialDelaySeconds: 60
               periodSeconds: 5
-            readinessProbe:
+          readinessProbe:
               httpGet:
                 path: /admin.index.php
                 port: http


### PR DESCRIPTION
readiness and livenessProbes are indented too far. They belong to the container element, not the ports list

Fixes #12