### PR TITLE
Implement Github Actions

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -1,0 +1,27 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Run chart-testing (lint)
+        id: lint
+        uses: helm/chart-testing-action@v1.0.0-alpha.3
+        with:
+          command: lint
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0-alpha.3
+        with:
+          install_local_path_provisioner: true
+        if: steps.lint.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        uses: helm/chart-testing-action@v1.0.0-alpha.3
+        with:
+          command: install

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,38 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      # See https://github.com/helm/chart-releaser-action/issues/6
+      - name: Install Helm
+        run: |
+          curl -sSLo get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get
+          chmod 700 get_helm.sh
+          ./get_helm.sh
+          helm init --client-only
+
+      - name: Add dependency chart repos
+        run: |
+          helm repo add stable https://kubernetes-charts.storage.googleapis.com/
+          helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.0.0-alpha.2
+        with:
+          charts_repo_url: https://mojo2600.github.io/pihole-kubernetes/
+        env:
+          CR_TOKEN: "${{ secrets.CR_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ serviceUDP:
 Then deploy everything with helm
 
 ```console
-$ cd pihole-kubernetes
-$ helm upgrade -i pihole ./pihole -f values.yaml
+helm repo add mojo2600 https://mojo2600.github.io/pihole-kubernetes/
+helm upgrade -i pihole mojo2600/pihole -f values.yaml
 ```
 
 You should now have a running pihole instance. You should be able to open the web UI under the url [http://192.168.178.252/admin](http://192.168.178.252/admin) and use the default password 'admin'.

--- a/ct.yaml
+++ b/ct.yaml
@@ -1,0 +1,4 @@
+helm-extra-args: --timeout 600
+chart-dirs:
+  - pihole
+

--- a/pihole/Chart.yaml
+++ b/pihole/Chart.yaml
@@ -1,10 +1,11 @@
 apiVersion: v1
 appVersion: "4.3.2-1"
 description: Installs pihole in kubernetes
-home: https://pi-hole.net/
+home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/pihole
 name: pihole
 version: 1.2.0
 sources:
+  - https://pi-hole.net/
   - https://github.com/pi-hole
   - https://github.com/pi-hole/docker-pi-hole
 icon: https://i2.wp.com/pi-hole.net/wp-content/uploads/2016/12/Vortex-R.png

--- a/pihole/README.md
+++ b/pihole/README.md
@@ -5,8 +5,9 @@ This directory contains a Kubernetes chart to deploy a
 
 ## TL;DR;
 
-```console
-$ helm upgrade -i pihole ./pihole -f values.yaml
+```shell
+helm repo add mojo2600 https://mojo2600.github.io/pihole-kubernetes/
+helm upgrade -i pihole mojo2600/pihole -f values.yaml
 ```
 
 ## My settings in values.yaml


### PR DESCRIPTION
Inspired by [this example repo](https://github.com/helm/chart-testing-action), this PR should implement GitHub Actions support which will:

* For every PR impacting the helm chart, a linter will make sure that the change passes linting which includes forcing a version bump on changes)
* For every PR impacting the helm chart, a 'kubernetes in docker' (KIND) cluster will be temporarily created and the chart will be installed to that test cluster to ensure that it installs properly
* For every merge to master impacting the helm chart, automation will package the chart, update the `index.yaml` on the `gh-pages` branch, and cut a github release with the packaged chart for reference as a chart repository.

**ACTION REQUIRED:**

* Github Pages should be enabled within the repo settings. Please use the default `gh-pages` branch
* Create a gtihub personal access token with `repo` permissions scope, make note of the token
* Create a new repo secret (accessible within the repo settings) named `CR_TOKEN` with the value being the github access token created above


This should go towards completing #11.  Another PR will arrive with cleanup to the `gh-pages` branch and a PR will need to be created on the [helm hub](https://github.com/helm/hub) to formally add this new repository & associated chart to https://hub.helm.sh/