### PR TITLE
Resolving issue with template access in ingress

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "4.3.2-1"
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/pihole
 name: pihole
-version: 1.3.0
+version: 1.3.1
 sources:
   - https://pi-hole.net/
   - https://github.com/pi-hole

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -81,8 +81,8 @@ The following table lists the configurable parameters of the pihole chart and th
 | admin.passwordKey | string | `"password"` |  |
 | affinity | object | `{}` |  |
 | blacklist | object | `{}` |  |
-| dnsmasq.additionalHostsEntries | object | `{}` |  |
-| dnsmasq.customDnsEntries | object | `[]` |  |
+| dnsmasq.additionalHostsEntries | array | `[]` |  |
+| dnsmasq.customDnsEntries | array | `[]` |  |
 | doh.enabled | bool | `false` |  |
 | doh.name | string | `"cloudflared"` |  |
 | doh.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -2,7 +2,7 @@ pihole
 ======
 Installs pihole in kubernetes
 
-Current chart version is `1.2.1`
+Current chart version is `1.3.0`
 
 Source code can be found [here](https://github.com/MoJo2600/pihole-kubernetes/tree/master/pihole)
 
@@ -77,6 +77,8 @@ The following table lists the configurable parameters of the pihole chart and th
 | DNS2 | string | `"8.8.4.4"` |  |
 | adlists | object | `{}` |  |
 | adminPassword | string | `"admin"` |  |
+| admin.existingSecret | string | `""` |  |
+| admin.passwordKey | string | `"password"` |  |
 | affinity | object | `{}` |  |
 | blacklist | object | `{}` |  |
 | dnsmasq.additionalHostsEntries | object | `{}` |  |

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -2,7 +2,7 @@ pihole
 ======
 Installs pihole in kubernetes
 
-Current chart version is `1.3.0`
+Current chart version is `1.3.1`
 
 Source code can be found [here](https://github.com/MoJo2600/pihole-kubernetes/tree/master/pihole)
 
@@ -82,7 +82,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | affinity | object | `{}` |  |
 | blacklist | object | `{}` |  |
 | dnsmasq.additionalHostsEntries | object | `{}` |  |
-| dnsmasq.customDnsEntries | object | `{}` |  |
+| dnsmasq.customDnsEntries | object | `[]` |  |
 | doh.enabled | bool | `false` |  |
 | doh.name | string | `"cloudflared"` |  |
 | doh.pullPolicy | string | `"IfNotPresent"` |  |
@@ -113,11 +113,11 @@ The following table lists the configurable parameters of the pihole chart and th
 | resources | object | `{}` |  |
 | serviceTCP.annotations | object | `{}` |  |
 | serviceTCP.externalTrafficPolicy | string | `"Local"` |  |
-| serviceTCP.loadBalancerIP | object | `{}` |  |
+| serviceTCP.loadBalancerIP | string | `""` |  |
 | serviceTCP.type | string | `"NodePort"` |  |
 | serviceUDP.annotations | object | `{}` |  |
 | serviceUDP.externalTrafficPolicy | string | `"Local"` |  |
-| serviceUDP.loadBalancerIP | object | `{}` |  |
+| serviceUDP.loadBalancerIP | string | `""` |  |
 | serviceUDP.type | string | `"NodePort"` |  |
 | tolerations | list | `[]` |  |
 | whitelist | object | `{}` |  |

--- a/charts/pihole/templates/ingress.yaml
+++ b/charts/pihole/templates/ingress.yaml
@@ -1,4 +1,5 @@
 {{- if .Values.ingress.enabled -}}
+{{- $serviceName := printf "%s-%s" (include "pihole.fullname" .) "tcp" -}}
 {{- $ingressPath := .Values.ingress.path -}}
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -31,7 +32,7 @@ spec:
         paths:
           - path: {{ $ingressPath }}
             backend:
-              serviceName: {{ template "pihole.fullname" . }}-tcp
+              serviceName: {{ $serviceName }}
               servicePort: http
   {{- end }}
 {{- end }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -123,7 +123,7 @@ dnsmasq:
   # - address=/foo.bar/192.168.178.10
   # - address=/bar.foo/192.168.178.11
 
-  additionalHostsEntries: {}
+  additionalHostsEntries: []
   # Dnsmasq reads the /etc/hosts file to resolve ips. You can add additional entries if you like
   # - 192.168.0.3     host4
   # - 192.168.0.4     host5

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -12,7 +12,7 @@ image:
 serviceTCP:
   type: NodePort
   externalTrafficPolicy: Local
-  loadBalancerIP: {}
+  loadBalancerIP: ""
     # a fixed LoadBalancer IP
   annotations: {}
     # metallb.universe.tf/address-pool: network-services
@@ -21,7 +21,7 @@ serviceTCP:
 serviceUDP:
   type: NodePort
   externalTrafficPolicy: Local
-  loadBalancerIP: {}
+  loadBalancerIP: ""
     # a fixed LoadBalancer IP
   annotations: {}
     # metallb.universe.tf/address-pool: network-services
@@ -115,7 +115,7 @@ doh:
   pullPolicy: IfNotPresent
 
 dnsmasq:
-  customDnsEntries: {}
+  customDnsEntries: []
   # Here you can add custom dns entries to override the
   # dns resolution with. All lines will be added to the
   # pihole dnsmasq configuration.


### PR DESCRIPTION
Ingress was not working with Helm v3 (did not test with v2) without a change to this reference.

While working in this space I was getting some warnings about type issues and updated those values to the types expected by the API.