### PR TITLE
Fix configmap-regex condition

### DIFF
--- a/charts/pihole/templates/configmap-regex.yaml
+++ b/charts/pihole/templates/configmap-regex.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.blacklist }}
+{{ if .Values.regex }}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
`regex` ConfigMap incorrectly checks for existence of `blacklist` values. This PR fixes that to allow `regex` list without having a dependency on the `blacklist`