### PR TITLE
Some improvements

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "4.3.2-1"
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/pihole
 name: pihole
-version: 1.3.2
+version: 1.3.3
 sources:
   - https://pi-hole.net/
   - https://github.com/pi-hole

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -158,7 +158,7 @@ spec:
       - name: config
         {{- if .Values.persistentVolumeClaim.enabled }}
         persistentVolumeClaim:
-          claimName: {{ template "pihole.fullname" . }}
+          claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "pihole.fullname" . }}{{- end }}
         {{- else }}
         emptyDir: {}
         {{- end }}

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -28,7 +28,8 @@ spec:
       dnsConfig:
         nameservers:
         - 127.0.0.1
-        - 8.8.8.8 
+        - 8.8.8.8
+      hostNetwork: {{ .Values.hostNetwork }}
       containers:
         {{- if .Values.doh.enabled }}
         - name: cloudflared
@@ -46,6 +47,8 @@ spec:
         {{- end }}
         - name: {{ .Chart.Name }}
           env:
+          - name: 'WEB_PORT'
+            value: "{{ .Values.webHttp }}"
           - name: WEBPASSWORD
             valueFrom:
               secretKeyRef:
@@ -72,8 +75,10 @@ spec:
          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            privileged: {{ .Values.privileged }}
           ports:
-          - containerPort: 80
+          - containerPort: {{ .Values.webHttp }}
             name: http
             protocol: TCP
           - containerPort: 53
@@ -82,7 +87,7 @@ spec:
           - containerPort: 53
             name: dns-udp
             protocol: UDP
-          - containerPort: 443
+          - containerPort:  {{ .Values.webHttps }}
             name: https
             protocol: TCP
           - containerPort: 67
@@ -185,5 +190,3 @@ spec:
           name: {{ template "pihole.fullname" . }}-regex
         name: regex
       {{- end }}
-
-

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -158,7 +158,7 @@ spec:
       - name: config
         {{- if .Values.persistentVolumeClaim.enabled }}
         persistentVolumeClaim:
-          claimName: {{ if .Values.persistence.existingClaim }}{{ .Values.persistence.existingClaim }}{{- else }}{{ template "pihole.fullname" . }}{{- end }}
+          claimName: {{ if .Values.persistentVolumeClaim.existingClaim }}{{ .Values.persistentVolumeClaim.existingClaim }}{{- else }}{{ template "pihole.fullname" . }}{{- end }}
         {{- else }}
         emptyDir: {}
         {{- end }}

--- a/charts/pihole/templates/service-tcp.yaml
+++ b/charts/pihole/templates/service-tcp.yaml
@@ -20,11 +20,11 @@ spec:
   externalTrafficPolicy: {{ .Values.serviceTCP.externalTrafficPolicy }}
   {{- end }}
   ports:
-    - port: 80
+    - port: 8000
       targetPort: http
       protocol: TCP
       name: http
-    - port: 443
+    - port: 8443
       targetPort: https
       protocol: TCP
       name: https

--- a/charts/pihole/templates/service-tcp.yaml
+++ b/charts/pihole/templates/service-tcp.yaml
@@ -20,11 +20,11 @@ spec:
   externalTrafficPolicy: {{ .Values.serviceTCP.externalTrafficPolicy }}
   {{- end }}
   ports:
-    - port: 8000
+    - port: 80
       targetPort: http
       protocol: TCP
       name: http
-    - port: 8443
+    - port: 443
       targetPort: https
       protocol: TCP
       name: https

--- a/charts/pihole/templates/service-tcp.yaml
+++ b/charts/pihole/templates/service-tcp.yaml
@@ -16,7 +16,9 @@ spec:
   {{- if .Values.serviceTCP.loadBalancerIP }}
   loadBalancerIP: {{ .Values.serviceTCP.loadBalancerIP }}
   {{- end }}
+  {{- if or (eq .Values.serviceUDP.type "NodePort") (eq .Values.serviceUDP.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceTCP.externalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: 80
       targetPort: http

--- a/charts/pihole/templates/service-udp.yaml
+++ b/charts/pihole/templates/service-udp.yaml
@@ -16,7 +16,9 @@ spec:
   {{- if .Values.serviceUDP.loadBalancerIP }}
   loadBalancerIP: {{ .Values.serviceUDP.loadBalancerIP }}
   {{- end }}
+  {{- if or (eq .Values.serviceUDP.type "NodePort") (eq .Values.serviceUDP.type "LoadBalancer") }}
   externalTrafficPolicy: Local
+  {{- end }}
   ports:
     - port: 53
       targetPort: dns-udp

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -145,3 +145,9 @@ blacklist: {}
 regex: {}
   # Add regular expression blacklist items
   # - (^|\.)facebook\.com$
+
+
+webHttp: "80"
+webHttps: "443"
+hostNetwork: "false"
+privileged: "false"


### PR DESCRIPTION
Hi,
First of all, thank you for the hard work building this Helm chart!

I'm author of a [guide about self-hosting](https://kauri.io/build-your-very-own-selfhosting-platform-with-rasp/5e1c3fdc1add0d0001dff534/c) with RapsberryPi boards and Kubernetes (k3s) and I wrote some articles on how to self-host applications and a specific one about [Pi-Hole using your chart](https://kauri.io/68-selfhost-pihole-on-kubernetes-and-block-ads-and/5268e3daace249aba7db0597b47591ef/a).

In this Pull-Request, I made a few improvements, mostly in the case when your router doesn't allow you to override the DNS address, so we have to disable DHCP on the router and enable it on Pi-Hole. However, in order to work (network broadcast on port 67), one of the solution consists in running the pod in **host networking mode** (see [official documentation](https://docs.pi-hole.net/docker/DHCP/#docker-pi-hole-with-host-networking-mode)).

So this is the content of this PR:

1. Ability to enable host network on the pod with the flag `hostNetwork: true`

2. Ability to give root access to the pod (`securityContext.privileged`) with the flag `privileged: true`
_I noticed the pod needs this to make DHCP work_

3. Ability to change the WebPort (http and https) because in host mode, it's very likely to conflict with something else (nginx for e.g)

4. A minor issue with the property `persistentVolumeClaim.existingClaim` which wasn't used in the deployment. I changed 

```
claimName: {{ template "pihole.fullname" . }}
```

to 

```
claimName: {{ if .Values.persistentVolumeClaim.existingClaim }}{{ .Values.persistentVolumeClaim.existingClaim }}{{- else }}{{ template "pihole.fullname" . }}{{- end }}
```

I know this is an important PR and I am ore than happy to discuss and make some changes if necessary to comply with your best practises.

Best,

Greg


-----------------------

Please find below my values

```yaml
replicaCount: 1

image:
  repository: "pihole/pihole"
  tag: "latest"
  pullPolicy: IfNotPresent

serviceTCP:
  type: ClusterIP

serviceUDP:
  type: ClusterIP

persistentVolumeClaim:
  existingClaim: "pihole-ssd"

nodeSelector:
  kubernetes.io/hostname: kube-master # Force the pod on a specific node of the cluster

admin:
  existingSecret: "pihole-secret"
  passwordKey: "password"

extraEnvVars:
  TZ: "Europe/London"
  ServerIP: 192.168.0.22 # Host IP

webHttp: "55080"
webHttps: "55443"
hostNetwork: "true"
privileged: "true"
```





