### PR TITLE
Add support for virtual host

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "4.3.2-1"
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/pihole
 name: pihole
-version: 1.3.3
+version: 1.5.0
 sources:
   - https://pi-hole.net/
   - https://github.com/pi-hole

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -49,6 +49,8 @@ spec:
           env:
           - name: 'WEB_PORT'
             value: "{{ .Values.webHttp }}"
+          - name: VIRTUAL_HOST
+            value: {{ .Values.virtualHost }}
           - name: WEBPASSWORD
             valueFrom:
               secretKeyRef:

--- a/charts/pihole/templates/ingress.yaml
+++ b/charts/pihole/templates/ingress.yaml
@@ -19,14 +19,14 @@ spec:
   tls:
   {{- range .Values.ingress.tls }}
     - hosts:
-      {{- range .hosts }}
+      {{- range append .hosts .Values.virtualHost }}
         - {{ . | quote }}
       {{- end }}
       secretName: {{ .secretName }}
   {{- end }}
 {{- end }}
   rules:
-  {{- range .Values.ingress.hosts }}
+  {{- range append .Values.ingress.hosts .Values.virtualHost }}
     - host: {{ . | quote }}
       http:
         paths:

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -27,6 +27,8 @@ serviceUDP:
     # metallb.universe.tf/address-pool: network-services
     # metallb.universe.tf/allow-shared-ip: pihole-svc
 
+virtualHost: pi.hole
+
 ingress:
   enabled: false
   annotations: {}
@@ -34,10 +36,12 @@ ingress:
     # kubernetes.io/tls-acme: "true"
   path: /
   hosts:
+    # virtualHost (default value is pi.hole) will be appended to the hosts
     - chart-example.local
   tls: []
   #  - secretName: chart-example-tls
   #    hosts:
+  #     #- virtualHost (default value is pi.hole) will be appended to the hosts
   #      - chart-example.local
 
 # Probes configuration


### PR DESCRIPTION
Pihole, uses default virtualhost `pi.hole`, if ingress is set with a
different name static assets no longer gets loaded since all the static
assets are still requested with `pi.hole`.

The change will bring in support for specifying different virtualhost
and use it ingress by default

Signed-off-by: Krishnaswamy Subramanian <jskswamy@gmail.com>