### PR TITLE
Add support for upstream DNS server

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "4.3.2-1"
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/pihole
 name: pihole
-version: 1.3.3
+version: 1.6.0
 sources:
   - https://pi-hole.net/
   - https://github.com/pi-hole

--- a/charts/pihole/templates/configmap.yaml
+++ b/charts/pihole/templates/configmap.yaml
@@ -10,6 +10,9 @@ metadata:
 data:
   02-custom.conf: |
     addn-hosts=/etc/addn-hosts
+  {{- range .Values.dnsmasq.upstreamServers }}
+    {{ . }}
+  {{- end }}
   {{- range .Values.dnsmasq.customDnsEntries }}
     {{ . }}
   {{- end }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -115,6 +115,13 @@ doh:
   pullPolicy: IfNotPresent
 
 dnsmasq:
+  upstreamServers: []
+  # Here you can add upstream dns servers with. All lines will be added to the
+  # pihole dnsmasq configuration.
+  # The format should be like:
+  # - server=/foo.bar/192.168.178.10
+  # - server=/bar.foo/192.168.178.11
+
   customDnsEntries: []
   # Here you can add custom dns entries to override the
   # dns resolution with. All lines will be added to the


### PR DESCRIPTION
Add ability for this chart to support upstream DNS server to be configured with dnsmasq.

Signed-off-by: Krishnaswamy Subramanian <jskswamy@gmail.com>