### PR TITLE
Restart pihole when config are changed

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "4.3.2-1"
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/pihole
 name: pihole
-version: 1.3.3
+version: 1.7.0
 sources:
   - https://pi-hole.net/
   - https://github.com/pi-hole

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -20,6 +20,12 @@ spec:
       release: {{ .Release.Name }}
   template:
     metadata:
+      annotations:
+        checksum.config.adlists: {{ include (print $.Template.BasePath "/configmap-adlists.yaml") . | sha256sum | trunc 63 }}
+        checksum.config.blacklist: {{ include (print $.Template.BasePath "/configmap-blacklist.yaml") . | sha256sum | trunc 63 }}
+        checksum.config.regex: {{ include (print $.Template.BasePath "/configmap-regex.yaml") . | sha256sum | trunc 63 }}
+        checksum.config.whitelist: {{ include (print $.Template.BasePath "/configmap-whitelist.yaml") . | sha256sum | trunc 63 }}
+        checksum.config.dnsmasqConfig: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
       labels:
         app: {{ template "pihole.name" . }}
         release: {{ .Release.Name }}


### PR DESCRIPTION
Any of the following configuration modification
requries restart to pihole for it to reload the configurations

 - adlists
 - blacklist
 - regex
 - whitelist
 - dnsmasq

Necessary annotations have been added to the deployment template
metadata section to reflect any changes to the configurations

Signed-off-by: Krishnaswamy Subramanian <jskswamy@gmail.com>