### PR TITLE
Fix ingress template tls section

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "4.3.2-1"
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/pihole
 name: pihole
-version: 1.7.0
+version: 1.7.1
 sources:
   - https://pi-hole.net/
   - https://github.com/pi-hole

--- a/charts/pihole/templates/ingress.yaml
+++ b/charts/pihole/templates/ingress.yaml
@@ -19,7 +19,7 @@ spec:
   tls:
   {{- range .Values.ingress.tls }}
     - hosts:
-      {{- range append .hosts .Values.virtualHost }}
+      {{- range append .hosts $.Values.virtualHost }}
         - {{ . | quote }}
       {{- end }}
       secretName: {{ .secretName }}


### PR DESCRIPTION
Without this patch, an ingress config will fail bacause of nested ranges confuses virtualHost value