### PR TITLE
Arpankapoor regex configmap fix

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "4.3.2-1"
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/pihole
 name: pihole
-version: 1.7.1
+version: 1.7.2
 sources:
   - https://pi-hole.net/
   - https://github.com/pi-hole

--- a/charts/pihole/templates/configmap-regex.yaml
+++ b/charts/pihole/templates/configmap-regex.yaml
@@ -1,4 +1,4 @@
-{{ if .Values.blacklist }}
+{{ if .Values.regex }}
 apiVersion: v1
 kind: ConfigMap
 metadata:


### PR DESCRIPTION
regex ConfigMap incorrectly checks for existence of blacklist values. This PR fixes that to allow regex list without having a dependency on the blacklist

Thanks @arpankapoor I updated the code and bumped the version to merge the fix for this bug