### PR TITLE
Add antiaffinity option to deployment

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "5.0"
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 1.7.8
+version: 1.7.9
 sources:
   - https://pi-hole.net/
   - https://github.com/pi-hole

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -30,6 +30,18 @@ spec:
         app: {{ template "pihole.name" . }}
         release: {{ .Release.Name }}
     spec:
+      {{- if .Values.antiaff.enabled }}
+      affinity:
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - labelSelector:
+              matchExpressions:
+              - key: release
+                operator: In
+                values:
+                - {{ .Values.antiaff.avoidRelease }}
+            topologyKey: "kubernetes.io/hostname"
+      {{- end }}
       dnsPolicy: "None"
       dnsConfig:
         nameservers:

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -116,6 +116,13 @@ extraEnvVarsSecret: {}
 DNS1: "8.8.8.8"
 DNS2: "8.8.4.4"
 
+antiaff:
+  # set to true to enable antiaffinity (example: 2 pihole DNS in the same cluster)
+  enabled: false
+  # Here you can set the pihole release (you set in `helm install <releasename> ...`)
+  # you want to avoid
+  avoidRelease: pihole1
+
 doh:
   # set to true to enabled DNS over HTTPs via cloudflared
   enabled: false


### PR DESCRIPTION
Add antiaffinity in deployement to avoid other pihole helm release scheduled in the same node.