### PR TITLE
New feature: HorizontalPodAutoscaler

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "5.1.2"
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 1.8.00
+version: 1.8.0
 sources:
   - https://pi-hole.net/
   - https://github.com/pi-hole

--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "5.1.2"
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 1.7.17
+version: 1.8.00
 sources:
   - https://pi-hole.net/
   - https://github.com/pi-hole

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -76,6 +76,10 @@ The following table lists the configurable parameters of the pihole chart and th
 | admin.passwordKey | string | `"password"` |  |
 | adminPassword | string | `"admin"` |  |
 | affinity | object | `{}` |  |
+| autoscaling | bool | `false` | Enable or disable Horizontal Pod Autoscaler |
+| autoscaling.minReplicas | int | 1 | Minimum number of replica's |
+| autoscaling.maxReplicas | int | 10 | Maximum number of replica's |
+| autoscaling.targetCPUUtilizationPercentage | int | 80 | Target average CPU utilization per pod. |
 | blacklist | object | `{}` |  |
 | dnsmasq.additionalHostsEntries | list | `[]` |  |
 | dnsmasq.customDnsEntries | list | `[]` |  |

--- a/charts/pihole/templates/horizontalPodAutoscaler.yml
+++ b/charts/pihole/templates/horizontalPodAutoscaler.yml
@@ -1,0 +1,14 @@
+{{- if .Values.autoscaling.enabled }}
+apiVersion: autoscaling/v1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ template "pihole.fullname" . }}-hpa
+spec:
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.autoscaling.maxReplicas }}
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ template "pihole.fullname" . }}
+  targetCPUUtilizationPercentage: {{ .Values.autoscaling.targetCPUUtilizationPercentage }}
+{{- end }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -78,7 +78,7 @@ autoscaling:
   # Set a limit on the number of replica's
   minReplicas: 1
   maxReplicas: 10
-  # The autoscaler will scale until every pod has this target level of CPU utilization (of the resources 
+  # The autoscaler will scale until every pod has this target level of CPU utilization (of the resources
   # limits, see above).
   # Documentation: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/
   targetCPUUtilizationPercentage: 80

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -78,7 +78,8 @@ autoscaling:
   # Set a limit on the number of replica's
   minReplicas: 1
   maxReplicas: 10
-  # The autoscaler will scale until every pod has this target level of CPU utilization.
+  # The autoscaler will scale until every pod has this target level of CPU utilization (of the resources 
+  # limits, see above).
   # Documentation: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/
   targetCPUUtilizationPercentage: 80
 

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -70,6 +70,19 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+autoscaling:
+  # Enable or disable the Horizontal Pod Autoscaler.
+  # This feature requires the metrics-server to be installed!
+  # See https://github.com/kubernetes-sigs/metrics-server
+  enabled: false
+  # Set a limit on the number of replica's
+  minReplicas: 1
+  maxReplicas: 10
+  # The autoscaler will scale until every pod has this target level of CPU utilization.
+  # Documentation: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/
+  targetCPUUtilizationPercentage: 80
+
+
 persistentVolumeClaim:
   # set to true to use pvc
   enabled: false


### PR DESCRIPTION
Added a new template for Horizontal Pod Autoscaler. Disabled by default.
To be able to use the autoscaling feature, the Kubernetes Metrics Server must be installed. See https://github.com/kubernetes-sigs/metrics-server. Test it out with:
`$ kubectl top pods`

To see the status of the scaler use:
`$ kubectl get hpa RELEASE_NAME [--namespace NAMESPACE]`

Usage:
```yaml
autoscaling:
  enabled: true
```

Configuration:
```yaml
autoscaling:
  # Enable or disable the Horizontal Pod Autoscaler.
  # This feature requires the metrics-server to be installed!
  # See https://github.com/kubernetes-sigs/metrics-server
  enabled: false
  # Set a limit on the number of replica's
  minReplicas: 1
  maxReplicas: 10
  # The autoscaler will scale until every pod has this target level of CPU utilization (of the resource limits).
  # Documentation: https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale-walkthrough/
  targetCPUUtilizationPercentage: 80
```