### PR TITLE
adding prometheus sidecar container and service monitor support

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "5.1.2"
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 1.7.17
+version: 1.7.18
 sources:
   - https://pi-hole.net/
   - https://github.com/pi-hole

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -67,58 +67,66 @@ The following table lists the configurable parameters of the pihole chart and th
 
 ## Chart Values
 
-| Key | Type | Default | Description |
-|-----|------|---------|-------------|
-| DNS1 | string | `"8.8.8.8"` |  |
-| DNS2 | string | `"8.8.4.4"` |  |
-| adlists | object | `{}` |  |
-| admin.existingSecret | string | `""` |  |
-| admin.passwordKey | string | `"password"` |  |
-| adminPassword | string | `"admin"` |  |
-| affinity | object | `{}` |  |
-| blacklist | object | `{}` |  |
-| dnsmasq.additionalHostsEntries | list | `[]` |  |
-| dnsmasq.customDnsEntries | list | `[]` |  |
-| doh.enabled | bool | `false` |  |
-| doh.name | string | `"cloudflared"` |  |
-| doh.pullPolicy | string | `"IfNotPresent"` |  |
-| doh.repository | string | `"crazymax/cloudflared"` |  |
-| doh.tag | string | `"latest"` |  |
-| doh.envVars | object | `{}` |  |
-| extraEnvVars | object | `{}` |  |
-| extraEnvVarsSecret | object | `{}` |  |
-| image.pullPolicy | string | `"IfNotPresent"` |  |
-| image.repository | string | `"pihole/pihole"` |  |
-| image.tag | string | `"5.1.1"` |  |
-| ingress.annotations | object | `{}` |  |
-| ingress.enabled | bool | `false` |  |
-| ingress.hosts[0] | string | `"chart-example.local"` |  |
-| ingress.path | string | `"/"` |  |
-| ingress.tls | list | `[]` |  |
-| nodeSelector | object | `{}` |  |
-| persistentVolumeClaim.accessModes[0] | string | `"ReadWriteOnce"` |  |
-| persistentVolumeClaim.annotations | object | `{}` |  |
-| persistentVolumeClaim.enabled | bool | `false` |  |
-| persistentVolumeClaim.existingClaim | bool | `false` |  |
-| persistentVolumeClaim.size | string | `"500Mi"` |  |
-| probes.liveness | object | `{"enabled":true,"failureThreshold":10,"initialDelaySeconds":60,"timeoutSeconds":5}` | Configure the healthcheck for the ingress controller |
-| probes.readiness.enabled | bool | `true` |  |
-| probes.readiness.failureThreshold | int | `3` |  |
-| probes.readiness.initialDelaySeconds | int | `60` |  |
-| probes.readiness.timeoutSeconds | int | `5` |  |
-| regex | object | `{}` |  |
-| replicaCount | int | `1` |  |
-| resources | object | `{}` |  |
-| serviceTCP.annotations | object | `{}` |  |
-| serviceTCP.externalTrafficPolicy | string | `"Local"` |  |
-| serviceTCP.loadBalancerIP | string | `""` |  |
-| serviceTCP.type | string | `"NodePort"` |  |
-| serviceUDP.annotations | object | `{}` |  |
-| serviceUDP.externalTrafficPolicy | string | `"Local"` |  |
-| serviceUDP.loadBalancerIP | string | `""` |  |
-| serviceUDP.type | string | `"NodePort"` |  |
-| tolerations | list | `[]` |  |
-| whitelist | object | `{}` |  |
+| Key                                  | Type   | Default                                                                              | Description                                          |
+|--------------------------------------|--------|--------------------------------------------------------------------------------------|------------------------------------------------------|
+| DNS1                                 | string | `"8.8.8.8"`                                                                          |                                                      |
+| DNS2                                 | string | `"8.8.4.4"`                                                                          |                                                      |
+| adlists                              | object | `{}`                                                                                 |                                                      |
+| admin.existingSecret                 | string | `""`                                                                                 |                                                      |
+| admin.passwordKey                    | string | `"password"`                                                                         |                                                      |
+| adminPassword                        | string | `"admin"`                                                                            |                                                      |
+| affinity                             | object | `{}`                                                                                 |                                                      |
+| blacklist                            | object | `{}`                                                                                 |                                                      |
+| dnsmasq.additionalHostsEntries       | list   | `[]`                                                                                 |                                                      |
+| dnsmasq.customDnsEntries             | list   | `[]`                                                                                 |                                                      |
+| doh.enabled                          | bool   | `false`                                                                              |                                                      |
+| doh.name                             | string | `"cloudflared"`                                                                      |                                                      |
+| doh.pullPolicy                       | string | `"IfNotPresent"`                                                                     |                                                      |
+| doh.repository                       | string | `"crazymax/cloudflared"`                                                             |                                                      |
+| doh.tag                              | string | `"latest"`                                                                           |                                                      |
+| doh.envVars                          | object | `{}`                                                                                 |                                                      |
+| extraEnvVars                         | object | `{}`                                                                                 |                                                      |
+| extraEnvVarsSecret                   | object | `{}`                                                                                 |                                                      |
+| image.pullPolicy                     | string | `"IfNotPresent"`                                                                     |                                                      |
+| image.repository                     | string | `"pihole/pihole"`                                                                    |                                                      |
+| image.tag                            | string | `"5.1.1"`                                                                            |                                                      |
+| ingress.annotations                  | object | `{}`                                                                                 |                                                      |
+| ingress.enabled                      | bool   | `false`                                                                              |                                                      |
+| ingress.hosts[0]                     | string | `"chart-example.local"`                                                              |                                                      |
+| ingress.path                         | string | `"/"`                                                                                |                                                      |
+| ingress.tls                          | list   | `[]`                                                                                 |                                                      |
+| nodeSelector                         | object | `{}`                                                                                 |                                                      |
+| persistentVolumeClaim.accessModes[0] | string | `"ReadWriteOnce"`                                                                    |                                                      |
+| persistentVolumeClaim.annotations    | object | `{}`                                                                                 |                                                      |
+| persistentVolumeClaim.enabled        | bool   | `false`                                                                              |                                                      |
+| persistentVolumeClaim.existingClaim  | bool   | `false`                                                                              |                                                      |
+| persistentVolumeClaim.size           | string | `"500Mi"`                                                                            |                                                      |
+| probes.liveness                      | object | `{"enabled":true,"failureThreshold":10,"initialDelaySeconds":60,"timeoutSeconds":5}` | Configure the healthcheck for the ingress controller |
+| probes.readiness.enabled             | bool   | `true`                                                                               |                                                      |
+| probes.readiness.failureThreshold    | int    | `3`                                                                                  |                                                      |
+| probes.readiness.initialDelaySeconds | int    | `60`                                                                                 |                                                      |
+| probes.readiness.timeoutSeconds      | int    | `5`                                                                                  |                                                      |
+| regex                                | object | `{}`                                                                                 |                                                      |
+| replicaCount                         | int    | `1`                                                                                  |                                                      |
+| resources                            | object | `{}`                                                                                 |                                                      |
+| serviceTCP.annotations               | object | `{}`                                                                                 |                                                      |
+| serviceTCP.externalTrafficPolicy     | string | `"Local"`                                                                            |                                                      |
+| serviceTCP.loadBalancerIP            | string | `""`                                                                                 |                                                      |
+| serviceTCP.type                      | string | `"NodePort"`                                                                         |                                                      |
+| serviceUDP.annotations               | object | `{}`                                                                                 |                                                      |
+| serviceUDP.externalTrafficPolicy     | string | `"Local"`                                                                            |                                                      |
+| serviceUDP.loadBalancerIP            | string | `""`                                                                                 |                                                      |
+| serviceUDP.type                      | string | `"NodePort"`                                                                         |                                                      |
+| tolerations                          | list   | `[]`                                                                                 |                                                      |
+| whitelist                            | object | `{}`                                                                                 |                                                      |
+| monitoring.serviceMonitor.enabled    | bool   | `false`                                                                              |                                                      |
+| monitoring.sidecar.enabled           | bool   | `false`                                                                              |                                                      |
+| monitoring.sidecar.port              | bool   | `9617`                                                                               |                                                      |
+| monitoring.sidecar.image.repository  | string | `ekofr/pihole-exporter`                                                              |                                                      |
+| monitoring.sidecar.image.tag         | bool   | `0.0.9`                                                                              |                                                      |
+| monitoring.sidecar.image.pullPolicy  | bool   | `IfNotPresent`                                                                       |                                                      |
+| monitoring.sidecar.resources         | object | `{}`                                                                                 |                                                      |
+
 
 ## HowTo
 

--- a/charts/pihole/ci/monitoring-values.yaml
+++ b/charts/pihole/ci/monitoring-values.yaml
@@ -1,0 +1,6 @@
+monitoring:
+  enabled: true
+  labels:
+    testExtraLabel: fofa
+  serviceMonitor:
+    enabled: false

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -56,6 +56,29 @@ spec:
         - 8.8.8.8
       hostNetwork: {{ .Values.hostNetwork }}
       containers:
+        {{- if .Values.monitoring.sidecar.enabled }}
+        - name: exporter
+          image: "{{ .Values.monitoring.sidecar.image.repository }}:{{ .Values.monitoring.sidecar.image.tag }}"
+          imagePullPolicy: {{ .Values.monitoring.sidecar.image.pullPolicy }}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          env:
+            - name: PIHOLE_HOSTNAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.podIP
+            - name: PIHOLE_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  key: {{ .Values.admin.passwordKey | default "password" }}
+                  name: {{ .Values.admin.existingSecret | default (include "pihole.password-secret" .) }}
+          resources:
+{{ toYaml .Values.monitoring.sidecar.resources | indent 12 }}
+          ports:
+            - containerPort: {{ .Values.monitoring.port }}
+              name: prometheus
+              protocol: TCP
+        {{- end }}
         {{- if .Values.doh.enabled }}
         - name: cloudflared
           image: "{{ .Values.doh.repository }}:{{ .Values.doh.tag }}"

--- a/charts/pihole/templates/servicemonitor.yaml
+++ b/charts/pihole/templates/servicemonitor.yaml
@@ -1,0 +1,43 @@
+{{- if .Values.monitoring.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  labels:
+    app: {{ template "pihole.name" . }}
+    chart: {{ template "pihole.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    {{- if .Values.monitoring.serviceMonitor.labels }}
+    {{ toYaml .Values.monitoring.serviceMonitor.labels }}
+    {{- end }}    
+  name: {{ template "pihole.fullname" . }}-prometheus-exporter
+{{- if .Values.monitoring.serviceMonitor.namespace }}
+  namespace: {{ .Values.monitoring.serviceMonitor.namespace }}
+{{- end }}
+spec:
+  endpoints:
+  - targetPort: {{ .Values.monitoring.port }}
+    path: /metrics
+{{- if .Values.monitoring.serviceMonitor.interval }}
+    interval: {{ .Values.monitoring.serviceMonitor.interval }}
+{{- end }}
+{{- if .Values.monitoring.serviceMonitor.bearerTokenFile }}
+    bearerTokenFile: {{ .Values.monitoring.serviceMonitor.bearerTokenFile }}
+{{- end }}
+{{- if .Values.monitoring.serviceMonitor.bearerTokenSecret }}
+    bearerTokenSecret:
+      name: {{ .Values.monitoring.serviceMonitor.bearerTokenSecret.name }}
+      key: {{ .Values.monitoring.serviceMonitor.bearerTokenSecret.key }}
+      {{- if .Values.monitoring.serviceMonitor.bearerTokenSecret.optional }}
+      optional: {{ .Values.monitoring.serviceMonitor.bearerTokenSecret.optional }}
+      {{- end }}
+{{- end }}
+  jobLabel: {{ template "pihole.fullname" . }}-prometheus-exporter
+  namespaceSelector:
+    matchNames:
+    - {{ .Release.Namespace }}
+  selector:
+    matchLabels:
+      app: {{ template "pihole.name" . }}
+      release: {{ .Release.Name }}
+{{- end }}

--- a/charts/pihole/templates/tests/test-pihole-endpoint.yml
+++ b/charts/pihole/templates/tests/test-pihole-endpoint.yml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ .Release.Name }}-smoke-test"
+  annotations:
+    "helm.sh/hook": test
+spec:
+  containers:
+  - name: hook1-container
+    image: curlimages/curl
+    imagePullPolicy: IfNotPresent
+    command: ['sh', '-c', 'curl http://{{ template "pihole.fullname" . }}-tcp:80/']
+  restartPolicy: Never
+  terminationGracePeriodSeconds: 0

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -192,3 +192,20 @@ customVolumes:
     # any volume type can be used here
     # hostPath:
     #   path: "/mnt/data"
+
+monitoring:
+  serviceMonitor:
+    enabled: false
+  sidecar:
+    enabled: false
+    port: 9617
+    image:
+      repository: ekofr/pihole-exporter
+      tag: 0.0.9
+      pullPolicy: IfNotPresent
+    resources:
+      limits:
+        memory: 128Mi
+      # requests:
+      #  cpu: 100m
+      #  memory: 128Mi


### PR DESCRIPTION
Adding optional [eko/pihole-exporter](https://github.com/eko/pihole-exporter), as sidecar container for better [prometheus](https://prometheus.io/) integration.  