### PR TITLE
Add the prometheus port to the tcp service

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "5.1.2"
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 1.7.19
+version: 1.7.20
 sources:
   - https://pi-hole.net/
   - https://github.com/pi-hole

--- a/charts/pihole/templates/service-tcp.yaml
+++ b/charts/pihole/templates/service-tcp.yaml
@@ -32,6 +32,12 @@ spec:
       targetPort: dns
       protocol: TCP
       name: dns
+    {{- if .Values.monitoring.sidecar.enabled }}
+    - port: {{ .Values.monitoring.sidecar.port }}
+      targetPort: prometheus
+      protocol: TCP
+      name: prometheus
+    {{- end }}
   selector:
     app: {{ template "pihole.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
Adds the prometheus port to the tcp service if the monitoring sidecar is enabled. Allows prometheus to scrape the target by dns name (e.g. `pihole:9617`) instead of IP address.

Resolves MoJo2600/pihole-kubernetes#84