### PR TITLE
Make maxSurge and maxUnavailable configurable

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "5.2.1"
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 1.8.23
+version: 1.8.24
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -2,7 +2,7 @@
 
 Installs pihole in kubernetes
 
-![Version: 1.8.22](https://img.shields.io/badge/Version-1.8.22-informational?style=flat-square) ![AppVersion: 5.2](https://img.shields.io/badge/AppVersion-5.2-informational?style=flat-square)
+![Version: 1.8.24](https://img.shields.io/badge/Version-1.8.24-informational?style=flat-square) ![AppVersion: 5.2.1](https://img.shields.io/badge/AppVersion-5.2.1-informational?style=flat-square)
 
 ## Source Code
 
@@ -149,12 +149,14 @@ The following table lists the configurable parameters of the pihole chart and th
 | hostNetwork | string | `"false"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"pihole/pihole"` |  |
-| image.tag | string | `"v5.2"` |  |
+| image.tag | string | `"v5.2.1"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts[0] | string | `"chart-example.local"` |  |
 | ingress.path | string | `"/"` |  |
 | ingress.tls | list | `[]` |  |
+| maxSurge | int | `1` |  |
+| maxUnavailable | int | `1` |  |
 | monitoring.podMonitor.enabled | bool | `false` |  |
 | monitoring.sidecar.enabled | bool | `false` |  |
 | monitoring.sidecar.image.pullPolicy | string | `"IfNotPresent"` |  |

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -12,8 +12,8 @@ spec:
   strategy:
     type: RollingUpdate
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 1
+      maxSurge: {{ .Values.maxSurge }}
+      maxUnavailable: {{ .Values.maxUnavailable }}
   selector:
     matchLabels:
       app: {{ template "pihole.name" . }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -4,6 +4,9 @@
 
 replicaCount: 1
 
+maxSurge: 1
+maxUnavailable: 1
+
 image:
   repository: "pihole/pihole"
   tag: v5.2.1


### PR DESCRIPTION
This PR makes `maxSurge` and `maxUnavailable` configurable.

I have Pihole configured as my only DNS resolver in my router.

If `maxSurge` is set to `1` the existing pod will be terminated before the new one is created. This causes the the download of the new image to fail because DNS isn't able to resolve.