### PR TITLE
Fixed wrong helm urls

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -27,8 +27,8 @@ jobs:
 
       - name: Add dependency chart repos
         run: |
-          helm repo add stable https://kubernetes-charts.storage.googleapis.com/
-          helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
+          helm repo add stable https://charts.helm.sh/stable
+          helm repo add incubator https://charts.helm.sh/incubator 
 
       - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.0.0-alpha.2


### PR DESCRIPTION
Release generation does not work because of wrong urls