### PR TITLE
Update pi-hole to 5.2.3

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v1
-appVersion: "5.2.1"
+appVersion: "5.2.3"
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 1.8.27
+version: 1.8.28
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -2,7 +2,7 @@
 
 Installs pihole in kubernetes
 
-![Version: 1.8.26](https://img.shields.io/badge/Version-1.8.26-informational?style=flat-square) ![AppVersion: 5.2.1](https://img.shields.io/badge/AppVersion-5.2.1-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+![Version: 1.8.28](https://img.shields.io/badge/Version-1.8.28-informational?style=flat-square) ![AppVersion: 5.2.3](https://img.shields.io/badge/AppVersion-5.2.3-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-27-blue.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
@@ -156,7 +156,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | hostNetwork | string | `"false"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"pihole/pihole"` |  |
-| image.tag | string | `"v5.2.1"` |  |
+| image.tag | string | `"v5.4"` |  |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts[0] | string | `"chart-example.local"` |  |

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -9,7 +9,7 @@ maxUnavailable: 1
 
 image:
   repository: "pihole/pihole"
-  tag: v5.2.1
+  tag: v5.4
   pullPolicy: IfNotPresent
 
 serviceDns:


### PR DESCRIPTION
I hope I've done this the right way. Please let me know if it needs any changes.

This changes pi-hole to the latest 5.2.3 release.

Specific versions from the footer of the UI:
- Pi-hole v5.2.3
- Web Interface v5.3
- FTL v5.4 
