### PR TITLE
set loadbalancer ip as DNS server for dhcp leases if available

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "5.2.4"
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 1.8.29
+version: 1.8.30
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/templates/configmap.yaml
+++ b/charts/pihole/templates/configmap.yaml
@@ -16,6 +16,9 @@ data:
   {{- range .Values.dnsmasq.customDnsEntries }}
     {{ . }}
   {{- end }}
+  {{- if .Values.serviceDns.loadBalancerIP }}
+    dhcp-option=6,{{ .Values.serviceDns.loadBalancerIP }}
+  {{- end }}
   addn-hosts: |
   {{- range .Values.dnsmasq.additionalHostsEntries }}
     {{ . }}


### PR DESCRIPTION
DHCP leases will contain the loadbalancer IP as DNS server. If the pod is rescheduled in this scenario DNS will still work. 
Tested on my local cluster with purelb as loadbalancer. 