### PR TITLE
Configurable web service ports, host port and deployment strategy type

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: "5.2.4"
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 1.8.31
+version: 1.8.32
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -2,7 +2,7 @@
 
 Installs pihole in kubernetes
 
-![Version: 1.8.29](https://img.shields.io/badge/Version-1.8.29-informational?style=flat-square) ![AppVersion: 5.2.4](https://img.shields.io/badge/AppVersion-5.2.4-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+![Version: 1.8.30](https://img.shields.io/badge/Version-1.8.30-informational?style=flat-square) ![AppVersion: 5.2.4](https://img.shields.io/badge/AppVersion-5.2.4-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-27-blue.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
@@ -137,6 +137,8 @@ The following table lists the configurable parameters of the pihole chart and th
 | blacklist | object | `{}` |  |
 | customVolumes.config | object | `{}` |  |
 | customVolumes.enabled | bool | `false` |  |
+| dnsHostPort.enabled | bool | `false` |  |
+| dnsHostPort.port | int | `53` |  |
 | dnsmasq.additionalHostsEntries | list | `[]` |  |
 | dnsmasq.customDnsEntries | list | `[]` |  |
 | dnsmasq.staticDhcpEntries | list | `[]` |  |
@@ -191,8 +193,13 @@ The following table lists the configurable parameters of the pihole chart and th
 | serviceDns.type | string | `"NodePort"` |  |
 | serviceWeb.annotations | object | `{}` |  |
 | serviceWeb.externalTrafficPolicy | string | `"Local"` |  |
+| serviceWeb.http.enabled | bool | `true` |  |
+| serviceWeb.http.port | int | `80` |  |
+| serviceWeb.https.enabled | bool | `true` |  |
+| serviceWeb.https.port | int | `443` |  |
 | serviceWeb.loadBalancerIP | string | `""` |  |
 | serviceWeb.type | string | `"ClusterIP"` |  |
+| strategy | string | `"RollingUpdate"` |  |
 | tolerations | list | `[]` |  |
 | virtualHost | string | `"pi.hole"` |  |
 | webHttp | string | `"80"` |  |

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -2,7 +2,7 @@
 
 Installs pihole in kubernetes
 
-![Version: 1.8.30](https://img.shields.io/badge/Version-1.8.30-informational?style=flat-square) ![AppVersion: 5.2.4](https://img.shields.io/badge/AppVersion-5.2.4-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+![Version: 1.8.31](https://img.shields.io/badge/Version-1.8.31-informational?style=flat-square) ![AppVersion: 5.2.4](https://img.shields.io/badge/AppVersion-5.2.4-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-27-blue.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
@@ -155,6 +155,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | doh.tag | string | `"latest"` |  |
 | extraEnvVars | object | `{}` |  |
 | extraEnvVarsSecret | object | `{}` |  |
+| ftl | object | `{}` |  |
 | hostNetwork | string | `"false"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"pihole/pihole"` |  |
@@ -205,7 +206,6 @@ The following table lists the configurable parameters of the pihole chart and th
 | webHttp | string | `"80"` |  |
 | webHttps | string | `"443"` |  |
 | whitelist | object | `{}` |  |
-| ftl | object | `{}` |  |
 
 ## Maintainers
 

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -199,7 +199,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | serviceWeb.https.port | int | `443` |  |
 | serviceWeb.loadBalancerIP | string | `""` |  |
 | serviceWeb.type | string | `"ClusterIP"` |  |
-| strategy | string | `"RollingUpdate"` |  |
+| strategyType | string | `"RollingUpdate"` |  |
 | tolerations | list | `[]` |  |
 | virtualHost | string | `"pi.hole"` |  |
 | webHttp | string | `"80"` |  |

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -163,9 +163,15 @@ spec:
           - containerPort: 53
             name: dns
             protocol: TCP
+          {{- if .Values.dnsHostPort.enabled }}
+            hostPort: {{ .Values.dnsHostPort.port }}
+          {{- end }}
           - containerPort: 53
             name: dns-udp
             protocol: UDP
+          {{- if .Values.dnsHostPort.enabled }}
+            hostPort: {{ .Values.dnsHostPort.port }}
+          {{- end }}
           - containerPort:  {{ .Values.webHttps }}
             name: https
             protocol: TCP

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
-    type: RollingUpdate
+    type: {{ .Values.strategy }}
     rollingUpdate:
       maxSurge: {{ .Values.maxSurge }}
       maxUnavailable: {{ .Values.maxUnavailable }}

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -10,7 +10,7 @@ metadata:
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
-    type: {{ .Values.strategy }}
+    type: {{ .Values.strategyType }}
     rollingUpdate:
       maxSurge: {{ .Values.maxSurge }}
       maxUnavailable: {{ .Values.maxUnavailable }}

--- a/charts/pihole/templates/service-web.yaml
+++ b/charts/pihole/templates/service-web.yaml
@@ -20,14 +20,18 @@ spec:
   externalTrafficPolicy: {{ .Values.serviceWeb.externalTrafficPolicy }}
   {{- end }}
   ports:
-    - port: 80
+    {{- if .Values.serviceWeb.http.enabled }}
+    - port: {{ .Values.serviceWeb.http.port }}
       targetPort: http
       protocol: TCP
       name: http
-    - port: 443
+    {{- end }}
+    {{- if .Values.serviceWeb.https.enabled }}
+    - port: {{ .Values.serviceWeb.https.port }}
       targetPort: https
       protocol: TCP
       name: https
+    {{- end }}
     {{- if .Values.doh.enabled }}
     - port: 49312
       protocol: TCP

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -4,7 +4,7 @@
 
 replicaCount: 1
 
-strategy: RollingUpdate
+strategyType: RollingUpdate
 maxSurge: 1
 maxUnavailable: 1
 

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -13,6 +13,10 @@ image:
   tag: v5.5.1
   pullPolicy: IfNotPresent
 
+dnsHostPort:
+  enabled: false
+  port: 53
+
 serviceDns:
   type: NodePort
   externalTrafficPolicy: Local

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -4,6 +4,7 @@
 
 replicaCount: 1
 
+strategy: RollingUpdate
 maxSurge: 1
 maxUnavailable: 1
 

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -22,6 +22,12 @@ serviceDns:
     # metallb.universe.tf/allow-shared-ip: pihole-svc
 
 serviceWeb:
+  http:
+    enabled: true
+    port: 80
+  https:
+    enabled: true
+    port: 443
   type: ClusterIP
   externalTrafficPolicy: Local
   loadBalancerIP: ""


### PR DESCRIPTION
This PR makes the following configurable:
- The web service ports - this is useful in situations when an alternative load balancer implementation like Rancher's ServiceLB is used: https://rancher.com/docs/k3s/latest/en/networking/#service-load-balancer
- `hostPort` for DNS - can be useful when using a LoadBalancer type service is not an option
- strategy type for Deployment - can to be set to `Recreate` to avoid PVC binding issues on clusters with multiple hosts
