### PR TITLE
Fix strategyType: Recreate

### DIFF
--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -11,9 +11,11 @@ spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
     type: {{ .Values.strategyType }}
+    {{- if eq .Values.strategyType "RollingUpdate" }}
     rollingUpdate:
       maxSurge: {{ .Values.maxSurge }}
       maxUnavailable: {{ .Values.maxUnavailable }}
+    {{- end }}
   selector:
     matchLabels:
       app: {{ template "pihole.name" . }}


### PR DESCRIPTION
I have noticed a mistake on my previous PR that has been merged: https://github.com/MoJo2600/pihole-kubernetes/pull/137

The `.spec.strategy.rollingUpdate` section of the deployment is only valid when strategy is set to `RollingUpdate`. This caused `--set strategyType=Recreate` to fail with the following:
```
Error: UPGRADE FAILED: cannot patch "pihole" with kind Deployment: Deployment.apps "pihole" is invalid: spec.strategy.rollingUpdate: Forbidden: may not be specified when strategy `type` is 'Recreate'
```

I have tested the other functionality on the PR #137, but missed this one.
This PR fixes the issue. Sorry for the mistake.