### PR TITLE
feat/disable service

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 1.9.1
+version: 1.10.0
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -1,9 +1,8 @@
 apiVersion: v1
-appVersion: "5.2.4"
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 1.9.0
+version: 1.9.1
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -2,7 +2,7 @@
 
 Installs pihole in kubernetes
 
-![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+![Version: 1.10.0](https://img.shields.io/badge/Version-1.10.0-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-27-blue.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
@@ -189,6 +189,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | replicaCount | int | `1` |  |
 | resources | object | `{}` |  |
 | serviceDns.annotations | object | `{}` |  |
+| serviceDns.enableTCP | bool | `true` | If true, the DNS service listens on TCP and UDP, not only on UDP |
 | serviceDns.externalTrafficPolicy | string | `"Local"` |  |
 | serviceDns.loadBalancerIP | string | `""` |  |
 | serviceDns.port | int | `53` |  |

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -2,7 +2,7 @@
 
 Installs pihole in kubernetes
 
-![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) ![AppVersion: 5.2.4](https://img.shields.io/badge/AppVersion-5.2.4-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+![Version: 1.9.0](https://img.shields.io/badge/Version-1.9.0-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-27-blue.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 

--- a/charts/pihole/templates/service-dns-tcp.yaml
+++ b/charts/pihole/templates/service-dns-tcp.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.monitoring.sidecar.enabled .Values.serviceDns.enableTCP }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -20,10 +21,12 @@ spec:
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
   {{- end }}
   ports:
+    {{- if .Values.serviceDns.enableTCP }}
     - port: {{ .Values.serviceDns.port }}
       targetPort: dns
       protocol: TCP
       name: dns
+    {{- end }}
     {{- if .Values.monitoring.sidecar.enabled }}
     - port: {{ .Values.monitoring.sidecar.port }}
       targetPort: prometheus
@@ -33,3 +36,4 @@ spec:
   selector:
     app: {{ template "pihole.name" . }}
     release: {{ .Release.Name }}
+{{- end }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -27,6 +27,9 @@ serviceDns:
     # metallb.universe.tf/address-pool: network-services
     # metallb.universe.tf/allow-shared-ip: pihole-svc
 
+  # -- If true, the DNS service listens on TCP and UDP, not only on UDP
+  enableTCP: true
+
 serviceWeb:
   http:
     enabled: true


### PR DESCRIPTION
This enables users to disable the DNS TCP service by setting `serviceDns.enableTCP` to `false`.

The change already incorporates #153 and should therfore merged after that one.