### PR TITLE
allow custom pod annotations

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -22,7 +22,7 @@ jobs:
           version: v3.4.0
 
       - name: Set up chart-testing
-        uses: helm/chart-testing-action@v2.0.1
+        uses: helm/chart-testing-action@v2.1.0
 
       - name: Run chart-testing (list-changed)
         id: list-changed
@@ -36,7 +36,7 @@ jobs:
         run: ct lint
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.1.0
+        uses: helm/kind-action@v1.2.0
         if: steps.list-changed.outputs.changed == 'true'
 
       - name: Run chart-testing (install)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -32,7 +32,7 @@ jobs:
           helm repo add incubator https://charts.helm.sh/incubator 
 
       - name: Run chart-releaser
-        uses: helm/chart-releaser-action@v1.2.0
+        uses: helm/chart-releaser-action@v1.2.1
         with:
           charts_repo_url: https://mojo2600.github.io/pihole-kubernetes/
         env:

--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 2.0.0
+version: 2.0.1
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -2,7 +2,7 @@
 
 Installs pihole in kubernetes
 
-![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+![Version: 2.0.1](https://img.shields.io/badge/Version-2.0.1-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-27-blue.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
@@ -188,6 +188,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | persistentVolumeClaim.annotations | object | `{}` |  |
 | persistentVolumeClaim.enabled | bool | `false` |  |
 | persistentVolumeClaim.size | string | `"500Mi"` |  |
+| podAnnotations | object | `{"prometheus.io/port": '9617', "prometheus.io/scrape": 'true'}` | Annotations for Deployment Pods |
 | privileged | string | `"false"` |  |
 | probes.liveness | object | `{"enabled":true,"failureThreshold":10,"initialDelaySeconds":60,"timeoutSeconds":5}` | Configure the healthcheck for the doh container |
 | probes.readiness.enabled | bool | `true` |  |
@@ -248,7 +249,7 @@ MetalLB 0.7.3 has a bug, where the service is not announced anymore, when the po
 
 Feel free to contribute by making a [pull request](https://github.com/MoJo2600/pihole-kubernetes/pull/new/master).
 
-Please read [Contribution Guide](CONTRIBUTING.md) for more information on how you can contribute to this Chart.
+Please read [Contribution Guide](../../CONTRIBUTING.md) for more information on how you can contribute to this Chart.
 
 ## Contributors ✨
 

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
         checksum.config.whitelist: {{ include (print $.Template.BasePath "/configmap-whitelist.yaml") . | sha256sum | trunc 63 }}
         checksum.config.dnsmasqConfig: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
         checksum.config.staticDhcpConfig: {{ include (print $.Template.BasePath "/configmap-static-dhcp.yaml") . | sha256sum | trunc 63 }}
+{{- with .Values.podAnnotations }}
+{{ toYaml . | indent 8 }}
+{{- end }}
       labels:
         app: {{ template "pihole.name" . }}
         release: {{ .Release.Name }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -256,6 +256,10 @@ customVolumes:
     # hostPath:
     #   path: "/mnt/data"
 
+podAnnotations: {}
+#  prometheus.io/port: '9617'
+#  prometheus.io/scrape: 'true'
+
 monitoring:
   podMonitor:
     enabled: false

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -257,11 +257,14 @@ customVolumes:
     #   path: "/mnt/data"
 
 podAnnotations: {}
-#  prometheus.io/port: '9617'
-#  prometheus.io/scrape: 'true'
+  # Additional annotations for Deployment Pods
+  # Example below allows Prometheus to scape on metric port (requires pihole-exporter sidecar enabled)
+  # prometheus.io/port: '9617'
+  # prometheus.io/scrape: 'true'
 
 monitoring:
   podMonitor:
+    # Preferably adding prometheus scrape annotations rather than enabling podMonitor.
     enabled: false
   sidecar:
     enabled: false


### PR DESCRIPTION
Added support for custom Pod annotations passed from Helm values.

Examples given for prometheus scrape annotations, possibly replacing the need of PodMonitor.