### PR TITLE
Misc non-critical fixes

### DIFF
--- a/charts/pihole/.helmignore
+++ b/charts/pihole/.helmignore
@@ -19,3 +19,9 @@
 .project
 .idea/
 *.tmproj
+
+# Manually added entries
+ci/
+examples/
+Makefile
+README.md.gotmpl

--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 2.1.1
+version: 2.1.2
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -25,6 +25,7 @@ spec:
       annotations:
         checksum.config.adlists: {{ include (print $.Template.BasePath "/configmap-adlists.yaml") . | sha256sum | trunc 63 }}
         checksum.config.blacklist: {{ include (print $.Template.BasePath "/configmap-blacklist.yaml") . | sha256sum | trunc 63 }}
+        checksum.config.ftl: {{ include (print $.Template.BasePath "/configmap-ftl.yaml") . | sha256sum | trunc 63 }}
         checksum.config.regex: {{ include (print $.Template.BasePath "/configmap-regex.yaml") . | sha256sum | trunc 63 }}
         checksum.config.whitelist: {{ include (print $.Template.BasePath "/configmap-whitelist.yaml") . | sha256sum | trunc 63 }}
         checksum.config.dnsmasqConfig: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}

--- a/charts/pihole/templates/podmonitor.yaml
+++ b/charts/pihole/templates/podmonitor.yaml
@@ -7,8 +7,8 @@ metadata:
     chart: {{ template "pihole.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-    {{- if .Values.monitoring.podMonitor.labels }}
-    {{ toYaml .Values.monitoring.podMonitor.labels }}
+    {{- with .Values.monitoring.podMonitor.labels }}
+    {{- . | toYaml | nindent 4 }}
     {{- end }}
   name: {{ template "pihole.fullname" . }}-prometheus-exporter
 {{- if .Values.monitoring.podMonitor.namespace }}

--- a/example/README.md
+++ b/example/README.md
@@ -1,6 +1,6 @@
 # Example configuration
 
-This example utilizes the option to add whitelists and blacklists on startup of the pihole container. With this setup you do not need to configure pihole afterwarts. The container is ready right from the start.
+This example utilizes the option to add whitelists and blacklists on startup of the pihole container. With this setup you do not need to configure pihole afterwards. The container is ready right from the start.
 
 * The blacklists are taken from [firebog](https://firebog.net/)
 * The whitelists are taken from [anudeepND’s curated whitelist](https://github.com/anudeepND/whitelist/blob/master/domains/whitelist.txt)


### PR DESCRIPTION
Hi @MoJo2600, thanks for making this Helm chart so I don't have to! :D

I found some small fixes while inspecting the Helm chart that I submit in this PR as four separate commits.

- Update .helmignore to not package unused files
- Restart on change to ftl configmap
- Fix documentation typo
- Fix formatting bug for monitoring.podMonitor.labels

---

Not part of this PR as I wasn't confident about it, but I would think that the /docs folder and the /example folder should be deleted from the repo at this point in time.

I was also very confused about this reference, I think these lines can be deleted but they may be used by the later referenced action but I don't think they are.

https://github.com/MoJo2600/pihole-kubernetes/blob/f04bdbf3818701435dba0e2619ddfac5e91303d8/.github/workflows/release.yaml#L29-L32