### PR TITLE
support mixed TCP and UDP DNS service

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 2.1.2
+version: 2.2.0
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -42,7 +42,7 @@ The following items can be set via `--set` flag during installation or configure
 dnsmasq:
   customDnsEntries:
     - address=/nas/192.168.178.10
- 
+
   customCnameEntries:
     - cname=foo.nas,nas
 
@@ -236,6 +236,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | serviceDhcp.loadBalancerIP | string | `""` | A fixed `spec.loadBalancerIP` for the DHCP Service |
 | serviceDhcp.type | string | `"NodePort"` | `spec.type` for the DHCP Service |
 | serviceDns | object | `{"annotations":{},"externalTrafficPolicy":"Local","loadBalancerIP":"","port":53,"type":"NodePort"}` | Configuration for the DNS service on port 53 |
+| serviceDns.mixedService | bool | `false` | Enabled creation of a mixed (TCP + UDP) service instead of separate services |
 | serviceDns.annotations | object | `{}` | Annotations for the DNS service |
 | serviceDns.externalTrafficPolicy | string | `"Local"` | `spec.externalTrafficPolicy` for the DHCP Service |
 | serviceDns.loadBalancerIP | string | `""` | A fixed `spec.loadBalancerIP` for the DNS Service |

--- a/charts/pihole/templates/service-dns-udp.yaml
+++ b/charts/pihole/templates/service-dns-udp.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.serviceDns.mixedService }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -27,3 +28,4 @@ spec:
   selector:
     app: {{ template "pihole.name" . }}
     release: {{ .Release.Name }}
+{{- end }}

--- a/charts/pihole/templates/service-dns.yaml
+++ b/charts/pihole/templates/service-dns.yaml
@@ -1,8 +1,8 @@
-{{- if not .Values.serviceDns.mixedService }}
+{{- if .Values.serviceDns.mixedService }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "pihole.fullname" . }}-dns-tcp
+  name: {{ template "pihole.fullname" . }}-dns
   labels:
     app: {{ template "pihole.name" . }}
     chart: {{ template "pihole.chart" . }}
@@ -25,6 +25,10 @@ spec:
       targetPort: dns
       protocol: TCP
       name: dns
+    - port: {{ .Values.serviceDns.port }}
+      targetPort: dns-udp
+      protocol: UDP
+      name: dns-udp
     {{- if .Values.monitoring.sidecar.enabled }}
     - port: {{ .Values.monitoring.sidecar.port }}
       targetPort: prometheus

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -31,6 +31,9 @@ dnsHostPort:
 # -- Configuration for the DNS service on port 53
 serviceDns:
 
+  # -- deploys a mixed (TCP + UDP) Service instead of separate ones
+  mixedService: false
+
   # -- `spec.type` for the DNS Service
   type: NodePort
 


### PR DESCRIPTION
add support for mixed DNS service (TCP and UDP)
keeping backwards compatibility by introducing `serviceDns.mixedService`.

---
fixes #78 
fixes #178