### PR TITLE
Migrate to new DNS env vars

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 2.1.2
+version: 2.2.1
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -151,7 +151,8 @@ spec:
             value: "127.0.0.1#5053"
           {{- else }}
           {{- if .Values.pihole.DNS1 }}
-          "PIHOLE_DNS_": {{ if .Values.DNS2 }}{{ ( printf "%v;%v" .Values.DNS1 .Values.DNS2 ) | squote }}{{ else }}{{ .Values.DNS1 | squote }}{{ end }}
+          - name: 'PIHOLE_DNS_'
+            value: {{ if .Values.DNS2 }}{{ ( printf "%v;%v" .Values.DNS1 .Values.DNS2 ) | squote }}{{ else }}{{ .Values.DNS1 | squote }}{{ end }}
          {{- end }}
          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -150,14 +150,9 @@ spec:
           - name: 'DNS2'
             value: "127.0.0.1#5053"
           {{- else }}
-          {{- if .Values.DNS1 }}
-          - name: 'DNS1'
-            value: {{ .Values.DNS1 }}
-          {{- end }}
-          {{- if .Values.DNS2 }}
-          - name: 'DNS2'
-            value: {{ .Values.DNS2 }}
-          {{- end }}
+          {{- if .Values.pihole.DNS1 }}
+          "PIHOLE_DNS_": {{ if .Values.DNS2 }}{{ ( printf "%v;%v" .Values.DNS1 .Values.DNS2 ) | squote }}{{ else }}{{ .Values.DNS1 | squote }}{{ end }}
+         {{- end }}
          {{- end }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -150,7 +150,7 @@ spec:
           - name: DNS2
             value: "127.0.0.1#5053"
           {{- else }}
-          {{- if .Values.pihole.DNS1 }}
+          {{- if .Values.DNS1 }}
           - name: 'PIHOLE_DNS_'
             value: {{ if .Values.DNS2 }}{{ ( printf "%v;%v" .Values.DNS1 .Values.DNS2 ) | squote }}{{ else }}{{ .Values.DNS1 | squote }}{{ end }}
          {{- end }}

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -147,7 +147,7 @@ spec:
           {{- if .Values.doh.enabled }}
           - name: 'DNS1'
             value: "127.0.0.1#5053"
-          - name: 'DNS2'
+          - name: DNS2
             value: "127.0.0.1#5053"
           {{- else }}
           {{- if .Values.pihole.DNS1 }}


### PR DESCRIPTION
This migrates to the new env-vars, while keeping the same "DNS1" and "DNS2" options (so should no cause any breaking changes).
