### PR TITLE
Support to set hostname of pod

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 2.2.1
+version: 2.4.0
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -2,7 +2,7 @@
 
 Installs pihole in kubernetes
 
-![Version: 2.2.1](https://img.shields.io/badge/Version-2.2.1-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+![Version: 2.4.0](https://img.shields.io/badge/Version-2.4.0-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-27-blue.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
@@ -201,6 +201,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | extraEnvVarsSecret | object | `{}` | extraEnvVarsSecret is a list of secrets to load in as environment variables. |
 | ftl | object | `{}` | values that should be added to pihole-FTL.conf |
 | hostNetwork | string | `"false"` | should the container use host network |
+| hostname | string | `""` | hostname of pod |
 | image.pullPolicy | string | `"IfNotPresent"` | the pull policy |
 | image.repository | string | `"pihole/pihole"` | the repostory to pull the image from |
 | image.tag | string | `"v5.8.1"` | the docker tag |

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -62,6 +62,7 @@ spec:
         nameservers:
         {{- toYaml .Values.podDnsConfig.nameservers | nindent 8 }}
       {{- end }}
+      hostname: {{ .Values.hostname }}
       hostNetwork: {{ .Values.hostNetwork }}
       containers:
         {{- if .Values.monitoring.sidecar.enabled }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -327,6 +327,9 @@ webHttp: "80"
 # -- port the container should use to expose HTTPS traffic
 webHttps: "443"
 
+# -- hostname of pod
+hostname: ""
+
 # -- should the container use host network
 hostNetwork: "false"
 


### PR DESCRIPTION
I've added support to set the hostname of the pod in order to better identify pihole instances.

The hostname is displayed in the top right corner of the pihole dashboard.