### PR TITLE
Add dualstack service support

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 2.2.1
+version: 2.3.0
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -2,7 +2,7 @@
 
 Installs pihole in kubernetes
 
-![Version: 2.2.1](https://img.shields.io/badge/Version-2.2.1-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+![Version: 2.3.0](https://img.shields.io/badge/Version-2.3.0-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-27-blue.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
@@ -197,6 +197,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | doh.pullPolicy | string | `"IfNotPresent"` |  |
 | doh.repository | string | `"crazymax/cloudflared"` |  |
 | doh.tag | string | `"latest"` |  |
+| dualStack.enabled | bool | `false` | set this to true to enable creation of DualStack services or creation of separate IPv6 services if `serviceDns.type` is set to `"LoadBalancer"` |
 | extraEnvVars | object | `{}` | extraEnvironmentVars is a list of extra enviroment variables to set for pihole to use |
 | extraEnvVarsSecret | object | `{}` | extraEnvVarsSecret is a list of secrets to load in as environment variables. |
 | ftl | object | `{}` | values that should be added to pihole-FTL.conf |
@@ -229,20 +230,22 @@ The following table lists the configurable parameters of the pihole chart and th
 | regex | object | `{}` | list of blacklisted regex expressions to import during initial start of the container |
 | replicaCount | int | `1` | The number of replicas |
 | resources | object | `{}` | We usually recommend not to specify default resources and to leave this as a conscious -- choice for the user. This also increases chances charts run on environments with little -- resources, such as Minikube. If you do want to specify resources, uncomment the following -- lines, adjust them as necessary, and remove the curly braces after 'resources:'. |
-| serviceDhcp | object | `{"annotations":{},"enabled":true,"externalTrafficPolicy":"Local","loadBalancerIP":"","type":"NodePort"}` | Configuration for the DHCP service on port 67 |
+| serviceDhcp | object | `{"annotations":{},"enabled":true,"externalTrafficPolicy":"Local","loadBalancerIP":"","loadBalancerIPv6":"","type":"NodePort"}` | Configuration for the DHCP service on port 67 |
 | serviceDhcp.annotations | object | `{}` | Annotations for the DHCP service |
 | serviceDhcp.enabled | bool | `true` | Generate a Service resource for DHCP traffic |
 | serviceDhcp.externalTrafficPolicy | string | `"Local"` | `spec.externalTrafficPolicy` for the DHCP Service |
 | serviceDhcp.loadBalancerIP | string | `""` | A fixed `spec.loadBalancerIP` for the DHCP Service |
+| serviceDhcp.loadBalancerIPv6 | string | `""` | A fixed `spec.loadBalancerIP` for the IPv6 DHCP Service |
 | serviceDhcp.type | string | `"NodePort"` | `spec.type` for the DHCP Service |
-| serviceDns | object | `{"annotations":{},"externalTrafficPolicy":"Local","loadBalancerIP":"","mixedService":false,"port":53,"type":"NodePort"}` | Configuration for the DNS service on port 53 |
+| serviceDns | object | `{"annotations":{},"externalTrafficPolicy":"Local","loadBalancerIP":"","loadBalancerIPv6":"","mixedService":false,"port":53,"type":"NodePort"}` | Configuration for the DNS service on port 53 |
 | serviceDns.annotations | object | `{}` | Annotations for the DNS service |
 | serviceDns.externalTrafficPolicy | string | `"Local"` | `spec.externalTrafficPolicy` for the DHCP Service |
 | serviceDns.loadBalancerIP | string | `""` | A fixed `spec.loadBalancerIP` for the DNS Service |
+| serviceDns.loadBalancerIPv6 | string | `""` | A fixed `spec.loadBalancerIP` for the IPv6 DNS Service |
 | serviceDns.mixedService | bool | `false` | deploys a mixed (TCP + UDP) Service instead of separate ones |
 | serviceDns.port | int | `53` | The port of the DNS service |
 | serviceDns.type | string | `"NodePort"` | `spec.type` for the DNS Service |
-| serviceWeb | object | `{"annotations":{},"externalTrafficPolicy":"Local","http":{"enabled":true,"port":80},"https":{"enabled":true,"port":443},"loadBalancerIP":"","type":"ClusterIP"}` | Configuration for the web interface service |
+| serviceWeb | object | `{"annotations":{},"externalTrafficPolicy":"Local","http":{"enabled":true,"port":80},"https":{"enabled":true,"port":443},"loadBalancerIP":"","loadBalancerIPv6":"","type":"ClusterIP"}` | Configuration for the web interface service |
 | serviceWeb.annotations | object | `{}` | Annotations for the DHCP service |
 | serviceWeb.externalTrafficPolicy | string | `"Local"` | `spec.externalTrafficPolicy` for the web interface Service |
 | serviceWeb.http | object | `{"enabled":true,"port":80}` | Configuration for the HTTP web interface listener |
@@ -252,6 +255,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | serviceWeb.https.enabled | bool | `true` | Generate a service for HTTPS traffic |
 | serviceWeb.https.port | int | `443` | The port of the web HTTPS service |
 | serviceWeb.loadBalancerIP | string | `""` | A fixed `spec.loadBalancerIP` for the web interface Service |
+| serviceWeb.loadBalancerIPv6 | string | `""` | A fixed `spec.loadBalancerIP` for the IPv6 web interface Service |
 | serviceWeb.type | string | `"ClusterIP"` | `spec.type` for the web interface Service |
 | strategyType | string | `"RollingUpdate"` | The `spec.strategyTpye` for updates |
 | tolerations | list | `[]` |  |

--- a/charts/pihole/templates/service-dhcp.yaml
+++ b/charts/pihole/templates/service-dhcp.yaml
@@ -14,6 +14,12 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.serviceDhcp.type }}
+  {{- if and (.Values.dualStack.enabled) (not (eq .Values.serviceDhcp.type "LoadBalancer")) }}
+  ipFamilies:
+  - IPv4
+  - IPv6
+  ipFamilyPolicy: PreferDualStack
+  {{- end }}
   {{- if .Values.serviceDhcp.loadBalancerIP }}
   loadBalancerIP: {{ .Values.serviceDhcp.loadBalancerIP }}
   {{- end }}
@@ -28,4 +34,39 @@ spec:
   selector:
     app: {{ template "pihole.name" . }}
     release: {{ .Release.Name }}
+---
+{{- if and (.Values.dualStack.enabled) (eq .Values.serviceDhcp.type "LoadBalancer") -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "pihole.fullname" . }}-dhcp-ivp6
+  labels:
+    app: {{ template "pihole.name" . }}
+    chart: {{ template "pihole.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.serviceDhcp.annotations }}
+  annotations:
+{{ toYaml .Values.serviceDhcp.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.serviceDhcp.type }}
+  ipFamilies:
+  - IPv6
+  ipFamilyPolicy: SingleStack
+  {{- if .Values.serviceDhcp.loadBalancerIPv6 }}
+  loadBalancerIP: {{ .Values.serviceDhcp.loadBalancerIPv6 }}
+  {{- end }}
+  {{- if or (eq .Values.serviceDhcp.type "NodePort") (eq .Values.serviceDhcp.type "LoadBalancer") }}
+  externalTrafficPolicy: {{ .Values.serviceDhcp.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+    - port: 67
+      targetPort: client-udp
+      protocol: UDP
+      name: client-udp
+  selector:
+    app: {{ template "pihole.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}
 {{- end }}

--- a/charts/pihole/templates/service-dns-tcp.yaml
+++ b/charts/pihole/templates/service-dns-tcp.yaml
@@ -14,6 +14,12 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.serviceDns.type }}
+  {{- if and (.Values.dualStack.enabled) (not (eq .Values.serviceDns.type "LoadBalancer")) }}
+  ipFamilies:
+  - IPv4
+  - IPv6
+  ipFamilyPolicy: PreferDualStack
+  {{- end }}
   {{- if .Values.serviceDns.loadBalancerIP }}
   loadBalancerIP: {{ .Values.serviceDns.loadBalancerIP }}
   {{- end }}
@@ -34,4 +40,45 @@ spec:
   selector:
     app: {{ template "pihole.name" . }}
     release: {{ .Release.Name }}
+---
+{{- if and (.Values.dualStack.enabled) (eq .Values.serviceDns.type "LoadBalancer") -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "pihole.fullname" . }}-dns-tcp-ipv6
+  labels:
+    app: {{ template "pihole.name" . }}
+    chart: {{ template "pihole.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.serviceDns.annotations }}
+  annotations:
+{{ toYaml .Values.serviceDns.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.serviceDns.type }}
+  ipFamilies:
+  - IPv6
+  ipFamilyPolicy: SingleStack
+  {{- if .Values.serviceDns.loadBalancerIPv6 }}
+  loadBalancerIP: {{ .Values.serviceDns.loadBalancerIPv6 }}
+  {{- end }}
+  {{- if or (eq .Values.serviceDns.type "NodePort") (eq .Values.serviceDns.type "LoadBalancer") }}
+  externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.serviceDns.port }}
+      targetPort: dns
+      protocol: TCP
+      name: dns
+    {{- if .Values.monitoring.sidecar.enabled }}
+    - port: {{ .Values.monitoring.sidecar.port }}
+      targetPort: prometheus
+      protocol: TCP
+      name: prometheus
+    {{- end }}
+  selector:
+    app: {{ template "pihole.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}
 {{- end }}

--- a/charts/pihole/templates/service-dns-udp.yaml
+++ b/charts/pihole/templates/service-dns-udp.yaml
@@ -14,6 +14,12 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.serviceDns.type }}
+  {{- if and (.Values.dualStack.enabled) (not (eq .Values.serviceDns.type "LoadBalancer")) }}
+  ipFamilies:
+  - IPv4
+  - IPv6
+  ipFamilyPolicy: PreferDualStack
+  {{- end }}
   {{- if .Values.serviceDns.loadBalancerIP }}
   loadBalancerIP: {{ .Values.serviceDns.loadBalancerIP }}
   {{- end }}
@@ -28,4 +34,39 @@ spec:
   selector:
     app: {{ template "pihole.name" . }}
     release: {{ .Release.Name }}
+---
+{{- if and (.Values.dualStack.enabled) (eq .Values.serviceDns.type "LoadBalancer") -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "pihole.fullname" . }}-dns-udp-ipv6
+  labels:
+    app: {{ template "pihole.name" . }}
+    chart: {{ template "pihole.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.serviceDns.annotations }}
+  annotations:
+{{ toYaml .Values.serviceDns.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.serviceDns.type }}
+  ipFamilies:
+  - IPv6
+  ipFamilyPolicy: SingleStack
+  {{- if .Values.serviceDns.loadBalancerIPv6 }}
+  loadBalancerIP: {{ .Values.serviceDns.loadBalancerIPv6 }}
+  {{- end }}
+  {{- if or (eq .Values.serviceDns.type "NodePort") (eq .Values.serviceDns.type "LoadBalancer") }}
+  externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.serviceDns.port }}
+      targetPort: dns-udp
+      protocol: UDP
+      name: dns-udp
+  selector:
+    app: {{ template "pihole.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}
 {{- end }}

--- a/charts/pihole/templates/service-dns.yaml
+++ b/charts/pihole/templates/service-dns.yaml
@@ -38,4 +38,49 @@ spec:
   selector:
     app: {{ template "pihole.name" . }}
     release: {{ .Release.Name }}
+---
+{{- if and (.Values.dualStack.enabled) (eq .Values.serviceDns.type "LoadBalancer") -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "pihole.fullname" . }}-dns-ipv6
+  labels:
+    app: {{ template "pihole.name" . }}
+    chart: {{ template "pihole.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.serviceDns.annotations }}
+  annotations:
+{{ toYaml .Values.serviceDns.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.serviceDns.type }}
+  ipFamilies:
+  - IPv6
+  ipFamilyPolicy: SingleStack
+  {{- if .Values.serviceDns.loadBalancerIPv6 }}
+  loadBalancerIP: {{ .Values.serviceDns.loadBalancerIPv6 }}
+  {{- end }}
+  {{- if or (eq .Values.serviceDns.type "NodePort") (eq .Values.serviceDns.type "LoadBalancer") }}
+  externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+    - port: {{ .Values.serviceDns.port }}
+      targetPort: dns
+      protocol: TCP
+      name: dns
+    - port: {{ .Values.serviceDns.port }}
+      targetPort: dns-udp
+      protocol: UDP
+      name: dns-udp
+    {{- if .Values.monitoring.sidecar.enabled }}
+    - port: {{ .Values.monitoring.sidecar.port }}
+      targetPort: prometheus
+      protocol: TCP
+      name: prometheus
+    {{- end }}
+  selector:
+    app: {{ template "pihole.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}
 {{- end }}

--- a/charts/pihole/templates/service-web.yaml
+++ b/charts/pihole/templates/service-web.yaml
@@ -13,6 +13,12 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.serviceWeb.type }}
+  {{- if and (.Values.dualStack.enabled) (not (eq .Values.serviceWeb.type "LoadBalancer")) }}
+  ipFamilies:
+  - IPv4
+  - IPv6
+  ipFamilyPolicy: PreferDualStack
+  {{- end }}
   {{- if .Values.serviceWeb.loadBalancerIP }}
   loadBalancerIP: {{ .Values.serviceWeb.loadBalancerIP }}
   {{- end }}
@@ -40,3 +46,51 @@ spec:
   selector:
     app: {{ template "pihole.name" . }}
     release: {{ .Release.Name }}
+---
+{{- if and (.Values.dualStack.enabled) (eq .Values.serviceWeb.type "LoadBalancer") -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "pihole.fullname" . }}-web-ipv6
+  labels:
+    app: {{ template "pihole.name" . }}
+    chart: {{ template "pihole.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.serviceWeb.annotations }}
+  annotations:
+{{ toYaml .Values.serviceWeb.annotations | indent 4 }}
+{{- end }}
+spec:
+  type: {{ .Values.serviceWeb.type }}
+  ipFamilies:
+  - IPv6
+  ipFamilyPolicy: SingleStack
+  {{- if .Values.serviceWeb.loadBalancerIPv6 }}
+  loadBalancerIP: {{ .Values.serviceWeb.loadBalancerIPv6 }}
+  {{- end }}
+  {{- if or (eq .Values.serviceWeb.type "NodePort") (eq .Values.serviceWeb.type "LoadBalancer") }}
+  externalTrafficPolicy: {{ .Values.serviceWeb.externalTrafficPolicy }}
+  {{- end }}
+  ports:
+    {{- if .Values.serviceWeb.http.enabled }}
+    - port: {{ .Values.serviceWeb.http.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+    {{- end }}
+    {{- if .Values.serviceWeb.https.enabled }}
+    - port: {{ .Values.serviceWeb.https.port }}
+      targetPort: https
+      protocol: TCP
+      name: https
+    {{- end }}
+    {{- if .Values.doh.enabled }}
+    - port: 49312
+      protocol: TCP
+      name: cloudflared-met
+    {{- end }}
+  selector:
+    app: {{ template "pihole.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -22,6 +22,10 @@ image:
   # -- the pull policy
   pullPolicy: IfNotPresent
 
+dualStack:
+  # -- set this to true to enable creation of DualStack services or creation of separate IPv6 services if `serviceDns.type` is set to `"LoadBalancer"`
+  enabled: false
+
 dnsHostPort:
   # -- set this to true to enable dnsHostPort
   enabled: false
@@ -45,7 +49,8 @@ serviceDns:
 
   # -- A fixed `spec.loadBalancerIP` for the DNS Service
   loadBalancerIP: ""
-    # a fixed LoadBalancer IP
+  # -- A fixed `spec.loadBalancerIP` for the IPv6 DNS Service
+  loadBalancerIPv6: ""
 
   # -- Annotations for the DNS service
   annotations: {}
@@ -66,6 +71,8 @@ serviceDhcp:
 
   # -- A fixed `spec.loadBalancerIP` for the DHCP Service
   loadBalancerIP: ""
+  # -- A fixed `spec.loadBalancerIP` for the IPv6 DHCP Service
+  loadBalancerIPv6: ""
 
   # -- Annotations for the DHCP service
   annotations: {}
@@ -99,7 +106,8 @@ serviceWeb:
 
   # -- A fixed `spec.loadBalancerIP` for the web interface Service
   loadBalancerIP: ""
-    # a fixed LoadBalancer IP
+  # -- A fixed `spec.loadBalancerIP` for the IPv6 web interface Service
+  loadBalancerIPv6: ""
 
   # -- Annotations for the DHCP service
   annotations: {}


### PR DESCRIPTION
This PR adds support for dualstack use cases.

If the service type is `LoadBalancer` and `dualStack.enabled` is `true` separate loadbalancer services will be created (one for IPv4 and one for IPv6).
If a different service type is being used the services will use `"ipFamilies": ["IPv4", "IPv6"]` and `"ipFamilyPolicy": "PreferDualStack"`.
The `loadBalancerIP` field for the IPv6 services can also be set.