### PR TITLE
Latest docker image - using new versioning scheme!

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 2.4.0
+version: 2.4.1
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -205,7 +205,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | hostname | string | `""` | hostname of pod |
 | image.pullPolicy | string | `"IfNotPresent"` | the pull policy |
 | image.repository | string | `"pihole/pihole"` | the repostory to pull the image from |
-| image.tag | string | `"v5.8.1"` | the docker tag |
+| image.tag | string | `"2021.09"` | the docker tag |
 | ingress | object | `{"annotations":{},"enabled":false,"hosts":["chart-example.local"],"path":"/","tls":[]}` | Configuration for the Ingress |
 | ingress.annotations | object | `{}` | Annotations for the ingress |
 | ingress.enabled | bool | `false` | Generate a Ingress resource |

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -18,7 +18,7 @@ image:
   # -- the repostory to pull the image from
   repository: "pihole/pihole"
   # -- the docker tag
-  tag: v5.8.1
+  tag: 2021.09
   # -- the pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
The docker-pi-hole team have introduced a new versioning scheme: Here's a quote from the [release notes](https://github.com/pi-hole/docker-pi-hole/releases/tag/2021.09):

> Previously, we have picked a version number of one of the internal components (most recently, FTL) and applied that to the docker container's tag. However, this sometimes causes confusion between users, but also developers (when we are not sure what to tag a docker release if FTL's version number has not changed)
> 
> **Going forward, we will use a year.month[.revision] to tag docker releases with.** To tag a new image, it is as simple as looking at the calendar to decide what the tag name should be. We will always try to leave any major changes until a new month rolls over. e.g if Pi-hole v6 were to be released in 2 weeks time, it would not be in the docker image until 2021.10 (that said, we can also tag pre-release versions for those that are itching to get onto the bleeding edge. This also gives us chance to make sure that none of the core Pi-hole changes break how the container operates.

This pull request bumps to the current release.