### PR TITLE
Updated image tag to pihole October release (2021.10)

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 2.4.1
+version: 2.4.2
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -205,7 +205,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | hostname | string | `""` | hostname of pod |
 | image.pullPolicy | string | `"IfNotPresent"` | the pull policy |
 | image.repository | string | `"pihole/pihole"` | the repostory to pull the image from |
-| image.tag | string | `"2021.09"` | the docker tag |
+| image.tag | string | `"2021.10"` | the docker tag |
 | ingress | object | `{"annotations":{},"enabled":false,"hosts":["chart-example.local"],"path":"/","tls":[]}` | Configuration for the Ingress |
 | ingress.annotations | object | `{}` | Annotations for the ingress |
 | ingress.enabled | bool | `false` | Generate a Ingress resource |

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -18,7 +18,7 @@ image:
   # -- the repostory to pull the image from
   repository: "pihole/pihole"
   # -- the docker tag
-  tag: 2021.09
+  tag: 2021.10
   # -- the pull policy
   pullPolicy: IfNotPresent
 

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -18,7 +18,7 @@ image:
   # -- the repostory to pull the image from
   repository: "pihole/pihole"
   # -- the docker tag
-  tag: 2021.10
+  tag: "2021.10"
   # -- the pull policy
   pullPolicy: IfNotPresent
 


### PR DESCRIPTION
Pi-Hole just released their (first) October release, tag 2021.10. I updated the manifests to use this image.

Link to the changelog: [docker-pi-hole Release 2021.10](https://github.com/pi-hole/docker-pi-hole/releases/tag/2021.10)