### PR TITLE
Feature: Add support for priorityClassName

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
-version: 2.5.1
+version: 2.5.2
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -259,6 +259,9 @@ spec:
       tolerations:
 {{ toYaml . | indent 8 }}
     {{- end }}
+    {{- if .Values.priorityClassName }}
+      priorityClassName: "{{ .Values.priorityClassName }}"
+    {{- end }}
     {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:
 {{ toYaml . | indent 8 }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -202,6 +202,9 @@ nodeSelector: {}
 
 tolerations: []
 
+# -- Specify a priorityClassName
+# priorityClassName: ""
+
 # Reference: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/
 topologySpreadConstraints: []
 # - maxSkew: <integer>


### PR DESCRIPTION
Since pihole can be a critical service on the network, this PR makes it possible to make the pihole pod a high priority one so that the network does not go down in the absence of cluster resources.