### PR TITLE
Add support for extraVolumes and extraVolumeMounts

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
 appVersion: 2021.10.1
-version: 2.5.3
+version: 2.5.4
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -177,6 +177,8 @@ The following table lists the configurable parameters of the pihole chart and th
 | blacklist | object | `{}` | list of blacklisted domains to import during initial start of the container |
 | customVolumes.config | object | `{}` | any volume type can be used here |
 | customVolumes.enabled | bool | `false` | set this to true to enable custom volumes |
+| extrasVolumes | object | `{}` | any extra volumes you might want |
+| extraVolumeMounts | object | `{}` | any extra volume mounts you might want |
 | dnsHostPort.enabled | bool | `false` | set this to true to enable dnsHostPort |
 | dnsHostPort.port | int | `53` | default port for this pod |
 | dnsmasq.additionalHostsEntries | list | `[]` | Dnsmasq reads the /etc/hosts file to resolve ips. You can add additional entries if you like |

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -245,6 +245,10 @@ spec:
             name: ftl
             subPath: pihole-FTL.conf
           {{- end }}
+          {{- range $key, $value := .Values.extraVolumeMounts }}
+          - name: {{ $key }}
+{{- toYaml $value | nindent 12 }}
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}
@@ -315,4 +319,8 @@ spec:
           defaultMode: 420
           name: {{ template "pihole.fullname" . }}-ftl
         name: ftl
+      {{- end }}
+      {{- range $key, $value := .Values.extraVolumes }}
+      - name: {{ $key }}
+{{- toYaml $value | nindent 8 }}
       {{- end }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -361,6 +361,18 @@ customVolumes:
     # hostPath:
     #   path: "/mnt/data"
 
+# -- any extra volumes you might want
+extraVolumes: {}
+  # external-conf:
+  #   configMap:
+  #     name: pi-hole-lighttpd-external-conf
+
+# -- any extra volume mounts you might want
+extraVolumeMounts: {}
+  # external-conf:
+  #   mountPath: /etc/lighttpd/external.conf
+  #   subPath: external.conf
+
 # -- Additional annotations for pods
 podAnnotations: {}
   # Example below allows Prometheus to scape on metric port (requires pihole-exporter sidecar enabled)


### PR DESCRIPTION
This PR adds the ability to have extra volumes into the container so it's possible to change other files.

I'm currently using this to change the `/etc/lighttpd/external.conf` file to allow adding an FQDN to the web-ui, and also to mount the SSL certificates to be used by it that are generated by `cert-manager`.

But this can be useful for many other purposes.

# Changes

* Add support for extraVolumes and extraVolumeMounts

# Example

This is how I'm using this feature.

```
extraVolumes:
  lighttpd-external-conf:
    hostPath:
      path: /mnt/storage/pi-hole/etc/lighttpd/external.conf
  lighttpd-ssl:
    secret:
      secretName: pi-hole-cert
extraVolumeMounts:
  lighttpd-external-conf:
    mountPath: /etc/lighttpd/external.conf
  lighttpd-ssl:
    mountPath: /etc/lighttpd/ssl
```