### PR TITLE
Allow to set the local DNS 

### DIFF
--- a/charts/pihole/templates/configmap-customlist.yaml
+++ b/charts/pihole/templates/configmap-customlist.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "pihole.fullname" . }}-customList
+  name: {{ template "pihole.fullname" . }}-custom-list
   labels:
     app: {{ template "pihole.name" . }}
     chart: {{ template "pihole.chart" . }}

--- a/charts/pihole/templates/configmap-customlist.yaml
+++ b/charts/pihole/templates/configmap-customlist.yaml
@@ -1,0 +1,16 @@
+{{ if not (empty .Values.localDns.dnsRecords) }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "pihole.fullname" . }}-customList
+  labels:
+    app: {{ template "pihole.name" . }}
+    chart: {{ template "pihole.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  custom.list: |
+  {{- range .Values.localDns.dnsRecords }}
+    {{ . }}
+  {{- end }}
+{{ end }}

--- a/charts/pihole/templates/configmap-setupVars.yaml
+++ b/charts/pihole/templates/configmap-setupVars.yaml
@@ -1,0 +1,16 @@
+{{ if .Values.setupVars }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ template "pihole.fullname" . }}-setupVars
+  labels:
+    app: {{ template "pihole.name" . }}
+    chart: {{ template "pihole.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+data:
+  pihole-setupVars.conf: |
+  {{- range $key, $value := .Values.setupVars }}
+    {{ $key }}={{ $value }}
+  {{- end }}
+{{ end }}

--- a/charts/pihole/templates/configmap-setupVars.yaml
+++ b/charts/pihole/templates/configmap-setupVars.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ template "pihole.fullname" . }}-setupVars
+  name: {{ template "pihole.fullname" . }}-setupvars
   labels:
     app: {{ template "pihole.name" . }}
     chart: {{ template "pihole.chart" . }}

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
         checksum.config.adlists: {{ include (print $.Template.BasePath "/configmap-adlists.yaml") . | sha256sum | trunc 63 }}
         checksum.config.blacklist: {{ include (print $.Template.BasePath "/configmap-blacklist.yaml") . | sha256sum | trunc 63 }}
         checksum.config.ftl: {{ include (print $.Template.BasePath "/configmap-ftl.yaml") . | sha256sum | trunc 63 }}
+        checksum.config.customlist: {{ include (print $.Template.BasePath "/configmap-customlist.yaml") . | sha256sum | trunc 63 }}
         checksum.config.regex: {{ include (print $.Template.BasePath "/configmap-regex.yaml") . | sha256sum | trunc 63 }}
         checksum.config.whitelist: {{ include (print $.Template.BasePath "/configmap-whitelist.yaml") . | sha256sum | trunc 63 }}
         checksum.config.dnsmasqConfig: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
@@ -245,6 +246,11 @@ spec:
             name: ftl
             subPath: pihole-FTL.conf
           {{- end }}
+          {{- if not (empty .Values.localDns.dnsRecords) }}
+          - mountPath: /etc/pihole/custom.list
+            name: custom-list
+            subPath: custom.list
+          {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
     {{- with .Values.nodeSelector }}
@@ -315,4 +321,10 @@ spec:
           defaultMode: 420
           name: {{ template "pihole.fullname" . }}-ftl
         name: ftl
+      {{- end }}
+      {{- if not (empty .Values.localDns.dnsRecords) }}
+      - configMap:
+          defaultMode: 420
+          name: {{ template "pihole.fullname" . }}-custom-list
+        name: custom-list
       {{- end }}

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -26,7 +26,7 @@ spec:
         checksum.config.adlists: {{ include (print $.Template.BasePath "/configmap-adlists.yaml") . | sha256sum | trunc 63 }}
         checksum.config.blacklist: {{ include (print $.Template.BasePath "/configmap-blacklist.yaml") . | sha256sum | trunc 63 }}
         checksum.config.ftl: {{ include (print $.Template.BasePath "/configmap-ftl.yaml") . | sha256sum | trunc 63 }}
-        checksum.config.setupVars: {{ include (print $.Template.BasePath "/configmap-setupVars.yaml") . | sha256sum | trunc 63 }}
+        checksum.config.setupvars: {{ include (print $.Template.BasePath "/configmap-setupVars.yaml") . | sha256sum | trunc 63 }}
         checksum.config.customlist: {{ include (print $.Template.BasePath "/configmap-customlist.yaml") . | sha256sum | trunc 63 }}
         checksum.config.regex: {{ include (print $.Template.BasePath "/configmap-regex.yaml") . | sha256sum | trunc 63 }}
         checksum.config.whitelist: {{ include (print $.Template.BasePath "/configmap-whitelist.yaml") . | sha256sum | trunc 63 }}
@@ -249,7 +249,7 @@ spec:
           {{- end }}
           {{- if .Values.setupVars }}
           - mountPath: /etc/pihole/setupVars.conf
-            name: ftl
+            name: setupvars
             subPath: setupVars.conf
           {{- end }}
           {{- if not (empty .Values.localDns.dnsRecords) }}
@@ -331,8 +331,8 @@ spec:
       {{- if .Values.setupVars }}
       - configMap:
           defaultMode: 420
-          name: {{ template "pihole.fullname" . }}-setupVars
-        name: setupVars
+          name: {{ template "pihole.fullname" . }}-setupvars
+        name: setupvars
       {{- end }}
       {{- if not (empty .Values.localDns.dnsRecords) }}
       - configMap:

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -26,6 +26,7 @@ spec:
         checksum.config.adlists: {{ include (print $.Template.BasePath "/configmap-adlists.yaml") . | sha256sum | trunc 63 }}
         checksum.config.blacklist: {{ include (print $.Template.BasePath "/configmap-blacklist.yaml") . | sha256sum | trunc 63 }}
         checksum.config.ftl: {{ include (print $.Template.BasePath "/configmap-ftl.yaml") . | sha256sum | trunc 63 }}
+        checksum.config.setupVars: {{ include (print $.Template.BasePath "/configmap-setupVars.yaml") . | sha256sum | trunc 63 }}
         checksum.config.customlist: {{ include (print $.Template.BasePath "/configmap-customlist.yaml") . | sha256sum | trunc 63 }}
         checksum.config.regex: {{ include (print $.Template.BasePath "/configmap-regex.yaml") . | sha256sum | trunc 63 }}
         checksum.config.whitelist: {{ include (print $.Template.BasePath "/configmap-whitelist.yaml") . | sha256sum | trunc 63 }}
@@ -246,6 +247,11 @@ spec:
             name: ftl
             subPath: pihole-FTL.conf
           {{- end }}
+          {{- if .Values.setupVars }}
+          - mountPath: /etc/pihole/setupVars.conf
+            name: ftl
+            subPath: setupVars.conf
+          {{- end }}
           {{- if not (empty .Values.localDns.dnsRecords) }}
           - mountPath: /etc/pihole/custom.list
             name: custom-list
@@ -321,6 +327,12 @@ spec:
           defaultMode: 420
           name: {{ template "pihole.fullname" . }}-ftl
         name: ftl
+      {{- end }}
+      {{- if .Values.setupVars }}
+      - configMap:
+          defaultMode: 420
+          name: {{ template "pihole.fullname" . }}-setupVars
+        name: setupVars
       {{- end }}
       {{- if not (empty .Values.localDns.dnsRecords) }}
       - configMap:

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -330,7 +330,7 @@ spec:
       {{- end }}
       {{- if .Values.setupVars }}
       - configMap:
-          defaultMode: 420
+          defaultMode: 777
           name: {{ template "pihole.fullname" . }}-setupvars
         name: setupvars
       {{- end }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -338,6 +338,13 @@ ftl: {}
   # Add values for pihole-FTL.conf
   # MAXDBDAYS: 14
 
+# -- values that should be added to custom.list
+localDns: 
+  dnsRecords:
+    []
+  # If you want to create some custom dns entry:
+  #   - 192.168.1.2 pihole.home.local
+
 # -- port the container should use to expose HTTP traffic
 webHttp: "80"
 

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -338,6 +338,9 @@ ftl: {}
   # Add values for pihole-FTL.conf
   # MAXDBDAYS: 14
 
+# -- values that should be added to setupVars.conf
+setupVars: {}
+
 # -- values that should be added to custom.list
 localDns: 
   dnsRecords:


### PR DESCRIPTION
Hi Guys,

Congratulations and thanks a lot for the nice job!

I am using the following pihole image as a work-around to the known bug that does not allow to write files in the /etc/pihole folder of the container: pi-hole/docker-pi-hole#922.

  tag: v5.8.1
 repository: pihole/pihole
Using your chart with this pihole version I could not set-up the local-dns entries since, in this case, they get written to /etc/pihole/custom.list. Unfortunately, I did not find any mention of this file in the pihole documentation... so I am not sure accepting the pull request is a good idea but this could help somebody else.

The pull request allows to write to the /etc/pihole/custom.list file using the variabl뮻e:
localDns.dnsRecords: []

Thank you again for your work!!

Best
Riccardo