### PR TITLE
fix: using apps/v1 instead beta version

### DIFF
--- a/classic/deployment-pihole.yml
+++ b/classic/deployment-pihole.yml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1 
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
error: unable to recognize "pihole/deployment-pihole.yml": no matches for kind "Deployment" in version `extensions/v1beta1`

using `apiVersion: apps/v1` works fine
