### PR TITLE
Add the ability to specify extra objects (manifests)

### DIFF
--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -202,6 +202,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | dualStack.enabled | bool | `false` | set this to true to enable creation of DualStack services or creation of separate IPv6 services if `serviceDns.type` is set to `"LoadBalancer"` |
 | extraEnvVars | object | `{}` | extraEnvironmentVars is a list of extra enviroment variables to set for pihole to use |
 | extraEnvVarsSecret | object | `{}` | extraEnvVarsSecret is a list of secrets to load in as environment variables. |
+| extraObjects | list | `[]` | any extra kubernetes manifests you might want |
 | ftl | object | `{}` | values that should be added to pihole-FTL.conf |
 | hostNetwork | string | `"false"` | should the container use host network |
 | hostname | string | `""` | hostname of pod |

--- a/charts/pihole/templates/extra-manifests.yaml
+++ b/charts/pihole/templates/extra-manifests.yaml
@@ -1,0 +1,4 @@
+{{ range .Values.extraObjects }}
+---
+{{ tpl (toYaml .) $ }}
+{{ end }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -373,6 +373,39 @@ extraVolumeMounts: {}
   #   mountPath: /etc/lighttpd/external.conf
   #   subPath: external.conf
 
+# -- any extra kubernetes manifests you might want
+extraObjects: []
+  # - apiVersion: v1
+  #   kind: ConfigMap
+  #   metadata:
+  #     name: pi-hole-lighttpd-external-conf
+  #   data:
+  #     external.conf: |
+  #       $HTTP["host"] =~ "example.foo" {
+  #         # If we're using a non-standard host for pihole, ensure the Pi-hole
+  #         # Block Page knows that this is not a blocked domain
+  #         setenv.add-environment = ("fqdn" => "true")
+  #
+  #         # Enable the SSL engine with a cert, only for this specific host
+  #         $SERVER["socket"] == ":443" {
+  #           ssl.engine = "enable"
+  #           ssl.pemfile = "/etc/ssl/lighttpd-private/tls.crt"
+  #           ssl.privkey = "/etc/ssl/lighttpd-private/tls.key"
+  #           ssl.ca-file = "/etc/ssl/lighttpd-private/ca.crt"
+  #           ssl.honor-cipher-order = "enable"
+  #           ssl.cipher-list = "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH"
+  #           ssl.use-sslv2 = "disable"
+  #           ssl.use-sslv3 = "disable"
+  #         }
+  #       }
+  #
+  #       # Redirect HTTP to HTTPS
+  #       $HTTP["scheme"] == "http" {
+  #         $HTTP["host"] =~ ".*" {
+  #           url.redirect = (".*" => "https://%0$0")
+  #         }
+  #       }
+
 # -- Additional annotations for pods
 podAnnotations: {}
   # Example below allows Prometheus to scape on metric port (requires pihole-exporter sidecar enabled)


### PR DESCRIPTION
I've seen this trend in other helm charts like [ArgoCD](https://github.com/argoproj/argo-helm/blob/master/charts/argo-cd/values.yaml#L62) and I really like being able to bundle my "extra" bits that shouldn't be part of the chart with the template. This allows tracking them in the same location so they never get forgotten and they're tied to the release (when it gets uninstalled)

In my specific chart I added:

```yaml
extraObjects:
  - apiVersion: cert-manager.io/v1
    kind: Certificate
    metadata:
      name: pihole-tls-cert
    spec:
      dnsNames:
        - "pihole.foo"
      ipAddresses:
        - "10.10.10.10"
      issuerRef:
        group: cert-manager.io
        kind: ClusterIssuer
        name: my-issuer
      secretName: pihole-tls-cert
  - apiVersion: v1
    kind: ConfigMap
    metadata:
      name: lighttpd-external-conf
    data:
      external.conf: |
        $HTTP["host"] =~ "pihole.foo" {
          # Ensure the Pi-hole Block Page knows that this is not a blocked domain
          setenv.add-environment = ("fqdn" => "true")
        
          # Enable the SSL engine with a LE cert, only for this specific host
          $SERVER["socket"] == ":443" {
            ssl.engine = "enable"
            ssl.pemfile = "/etc/ssl/lighttpd-private/tls.crt"
            ssl.privkey = "/etc/ssl/lighttpd-private/tls.key"
            ssl.ca-file = "/etc/ssl/lighttpd-private/ca.crt"
            ssl.honor-cipher-order = "enable"
            ssl.cipher-list = "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH"
            ssl.use-sslv2 = "disable"
            ssl.use-sslv3 = "disable"
          }
        }
        # Redirect HTTP to HTTPS
        $HTTP["scheme"] == "http" {
          $HTTP["host"] =~ ".*" {
            url.redirect = (".*" => "https://%0$0")
          }
        }
```

There should be no backward compatibility issues as this is a totally new field.