### PR TITLE
Removal: drop deprecated `spec.loadBalancerIP`

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
 appVersion: "2023.05.2"
-version: 2.19.0
+version: 3.0.0
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/README.md.gotmpl
+++ b/charts/pihole/README.md.gotmpl
@@ -46,15 +46,15 @@ persistentVolumeClaim:
   enabled: true
 
 serviceWeb:
-  loadBalancerIP: 192.168.178.252
   annotations:
     metallb.universe.tf/allow-shared-ip: pihole-svc
+    metallb.universe.tf/loadBalancerIPs: "192.168.178.252"
   type: LoadBalancer
 
 serviceDns:
-  loadBalancerIP: 192.168.178.252
   annotations:
     metallb.universe.tf/allow-shared-ip: pihole-svc
+    metallb.universe.tf/loadBalancerIPs: "192.168.178.252"
   type: LoadBalancer
 ```
 
@@ -104,27 +104,27 @@ update your `values.yaml` and add a new configuration for this new service.
 Before (In my case, with metallb):
 ```
 serviceTCP:
-  loadBalancerIP: 192.168.178.252
   annotations:
     metallb.universe.tf/allow-shared-ip: pihole-svc
+    metallb.universe.tf/loadBalancerIPs: "192.168.178.252"
 
 serviceUDP:
-  loadBalancerIP: 192.168.178.252
   annotations:
     metallb.universe.tf/allow-shared-ip: pihole-svc
+    metallb.universe.tf/loadBalancerIPs: "192.168.178.252"
 ```
 
 After:
 ```
 serviceWeb:
-  loadBalancerIP: 192.168.178.252
   annotations:
     metallb.universe.tf/allow-shared-ip: pihole-svc
+    metallb.universe.tf/loadBalancerIPs: "192.168.178.252"
 
 serviceDns:
-  loadBalancerIP: 192.168.178.252
   annotations:
     metallb.universe.tf/allow-shared-ip: pihole-svc
+    metallb.universe.tf/loadBalancerIPs: "192.168.178.252"
 ```
 
 Version 1.8.22 has switched from the deprecated ingress api `extensions/v1beta1` to the go forward version `networking.k8s.io/v1`. This means that your cluster must be running 1.19.x as this api is not available on older versions. If necessary to run on an older Kubernetes Version, it can be done by modifying the ingress.yaml and changing the api definition back. The backend definition would also change from:

--- a/charts/pihole/examples/k3s-values.yaml
+++ b/charts/pihole/examples/k3s-values.yaml
@@ -10,21 +10,21 @@ persistentVolumeClaim:
   enabled: true
 
 serviceWeb:
-  loadBalancerIP: 192.168.178.201
   annotations:
     metallb.universe.tf/allow-shared-ip: pihole-svc
+    metallb.universe.tf/loadBalancerIPs: "192.168.178.201"
   type: LoadBalancer
 
 serviceDns:
-  loadBalancerIP: 192.168.178.201
   annotations:
     metallb.universe.tf/allow-shared-ip: pihole-svc
+    metallb.universe.tf/loadBalancerIPs: "192.168.178.201"
   type: LoadBalancer
 
 serviceDhcp:
-  loadBalancerIP: 192.168.178.201
   annotations:
     metallb.universe.tf/allow-shared-ip: pihole-svc
+    metallb.universe.tf/loadBalancerIPs: "192.168.178.201"
   type: LoadBalancer
 
 podDnsConfig:

--- a/charts/pihole/examples/metallb-values.yaml
+++ b/charts/pihole/examples/metallb-values.yaml
@@ -6,14 +6,13 @@ persistentVolumeClaim:
   enabled: true
 
 serviceTCP:
-  loadBalancerIP: 192.168.178.253
   annotations:
     metallb.universe.tf/address-pool: network-services
     metallb.universe.tf/allow-shared-ip: pihole-svc
+    metallb.universe.tf/loadBalancerIPs: "192.168.178.253"
 
 serviceUDP:
-  loadBalancerIP: 192.168.178.253
   annotations:
     metallb.universe.tf/address-pool: network-services
     metallb.universe.tf/allow-shared-ip: pihole-svc
-
+    metallb.universe.tf/loadBalancerIPs: "192.168.178.253"

--- a/charts/pihole/templates/configmap.yaml
+++ b/charts/pihole/templates/configmap.yaml
@@ -16,9 +16,6 @@ data:
   {{- range .Values.dnsmasq.customDnsEntries }}
     {{ . }}
   {{- end }}
-  {{- if .Values.serviceDns.loadBalancerIP }}
-    dhcp-option=6,{{ .Values.serviceDns.loadBalancerIP }}
-  {{- end }}
   {{- range .Values.dnsmasq.customSettings }}
     {{ . }}
   {{- end }}

--- a/charts/pihole/templates/service-dhcp.yaml
+++ b/charts/pihole/templates/service-dhcp.yaml
@@ -20,9 +20,6 @@ spec:
   - IPv6
   ipFamilyPolicy: PreferDualStack
   {{- end }}
-  {{- if .Values.serviceDhcp.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.serviceDhcp.loadBalancerIP }}
-  {{- end }}
   {{- if or (eq .Values.serviceDhcp.type "NodePort") (eq .Values.serviceDhcp.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceDhcp.externalTrafficPolicy }}
   {{- end }}
@@ -57,9 +54,6 @@ spec:
   ipFamilies:
   - IPv6
   ipFamilyPolicy: SingleStack
-  {{- if .Values.serviceDhcp.loadBalancerIPv6 }}
-  loadBalancerIP: {{ .Values.serviceDhcp.loadBalancerIPv6 }}
-  {{- end }}
   {{- if or (eq .Values.serviceDhcp.type "NodePort") (eq .Values.serviceDhcp.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceDhcp.externalTrafficPolicy }}
   {{- end }}

--- a/charts/pihole/templates/service-dns-tcp.yaml
+++ b/charts/pihole/templates/service-dns-tcp.yaml
@@ -20,9 +20,6 @@ spec:
   - IPv6
   ipFamilyPolicy: PreferDualStack
   {{- end }}
-  {{- if .Values.serviceDns.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.serviceDns.loadBalancerIP }}
-  {{- end }}
   {{- if or (eq .Values.serviceDns.type "NodePort") (eq .Values.serviceDns.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
   {{- end }}
@@ -63,9 +60,6 @@ spec:
   ipFamilies:
   - IPv6
   ipFamilyPolicy: SingleStack
-  {{- if .Values.serviceDns.loadBalancerIPv6 }}
-  loadBalancerIP: {{ .Values.serviceDns.loadBalancerIPv6 }}
-  {{- end }}
   {{- if or (eq .Values.serviceDns.type "NodePort") (eq .Values.serviceDns.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
   {{- end }}

--- a/charts/pihole/templates/service-dns-udp.yaml
+++ b/charts/pihole/templates/service-dns-udp.yaml
@@ -20,9 +20,6 @@ spec:
   - IPv6
   ipFamilyPolicy: PreferDualStack
   {{- end }}
-  {{- if .Values.serviceDns.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.serviceDns.loadBalancerIP }}
-  {{- end }}
   {{- if or (eq .Values.serviceDns.type "NodePort") (eq .Values.serviceDns.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
   {{- end }}
@@ -57,9 +54,6 @@ spec:
   ipFamilies:
   - IPv6
   ipFamilyPolicy: SingleStack
-  {{- if .Values.serviceDns.loadBalancerIPv6 }}
-  loadBalancerIP: {{ .Values.serviceDns.loadBalancerIPv6 }}
-  {{- end }}
   {{- if or (eq .Values.serviceDns.type "NodePort") (eq .Values.serviceDns.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
   {{- end }}

--- a/charts/pihole/templates/service-dns.yaml
+++ b/charts/pihole/templates/service-dns.yaml
@@ -14,9 +14,6 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.serviceDns.type }}
-  {{- if .Values.serviceDns.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.serviceDns.loadBalancerIP }}
-  {{- end }}
   {{- if or (eq .Values.serviceDns.type "NodePort") (eq .Values.serviceDns.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
   {{- end }}
@@ -64,9 +61,6 @@ spec:
   ipFamilies:
   - IPv6
   ipFamilyPolicy: SingleStack
-  {{- if .Values.serviceDns.loadBalancerIPv6 }}
-  loadBalancerIP: {{ .Values.serviceDns.loadBalancerIPv6 }}
-  {{- end }}
   {{- if or (eq .Values.serviceDns.type "NodePort") (eq .Values.serviceDns.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
   {{- end }}

--- a/charts/pihole/templates/service-web.yaml
+++ b/charts/pihole/templates/service-web.yaml
@@ -19,9 +19,6 @@ spec:
   - IPv6
   ipFamilyPolicy: PreferDualStack
   {{- end }}
-  {{- if .Values.serviceWeb.loadBalancerIP }}
-  loadBalancerIP: {{ .Values.serviceWeb.loadBalancerIP }}
-  {{- end }}
   {{- if or (eq .Values.serviceWeb.type "NodePort") (eq .Values.serviceWeb.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceWeb.externalTrafficPolicy }}
   {{- end }}
@@ -72,9 +69,6 @@ spec:
   ipFamilies:
   - IPv6
   ipFamilyPolicy: SingleStack
-  {{- if .Values.serviceWeb.loadBalancerIPv6 }}
-  loadBalancerIP: {{ .Values.serviceWeb.loadBalancerIPv6 }}
-  {{- end }}
   {{- if or (eq .Values.serviceWeb.type "NodePort") (eq .Values.serviceWeb.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceWeb.externalTrafficPolicy }}
   {{- end }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -49,11 +49,6 @@ serviceDns:
   # -- `spec.externalTrafficPolicy` for the DHCP Service
   externalTrafficPolicy: Local
 
-  # -- A fixed `spec.loadBalancerIP` for the DNS Service
-  loadBalancerIP: ""
-  # -- A fixed `spec.loadBalancerIP` for the IPv6 DNS Service
-  loadBalancerIPv6: ""
-
   # -- Annotations for the DNS service
   annotations:
     {}
@@ -76,11 +71,6 @@ serviceDhcp:
 
   # -- `spec.externalTrafficPolicy` for the DHCP Service
   externalTrafficPolicy: Local
-
-  # -- A fixed `spec.loadBalancerIP` for the DHCP Service
-  loadBalancerIP: ""
-  # -- A fixed `spec.loadBalancerIP` for the IPv6 DHCP Service
-  loadBalancerIPv6: ""
 
   # -- Annotations for the DHCP service
   annotations:
@@ -117,11 +107,6 @@ serviceWeb:
 
   # -- `spec.externalTrafficPolicy` for the web interface Service
   externalTrafficPolicy: Local
-
-  # -- A fixed `spec.loadBalancerIP` for the web interface Service
-  loadBalancerIP: ""
-  # -- A fixed `spec.loadBalancerIP` for the IPv6 web interface Service
-  loadBalancerIPv6: ""
 
   # -- Annotations for the DHCP service
   annotations:


### PR DESCRIPTION
`spec.loadBalancerIP` is deprecated since v1.24 in favor of provider specific annotations (such as `metallb.universe.tf/loadBalancerIPs` for MetalLB)
> The.spec.loadBalancerIP field for a Service was deprecated in Kubernetes v1.24.
> 
> This field was under-specified and its meaning varies across implementations. It also cannot support dual-stack networking. > This field may be removed in a future API version.

Docs: https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer

PR: https://github.com/kubernetes/kubernetes/pull/107235

Fell free to adjust the version if you don't want major bumps for values removal.

FYI: You should somehow enforce the generation of the chart readme (`charts/pihole/README.md`), as it was missing some previously added values!