### PR TITLE
Add nodeport options for dhcp and web and make dhcp port configurable

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -485,6 +485,24 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "FernFerret",
+      "name": "Eric",
+      "avatar_url": "https://avatars.githubusercontent.com/u/72811?v=4",
+      "profile": "https://github.com/FernFerret",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "vince-vibin",
+      "name": "Vincent",
+      "avatar_url": "https://avatars.githubusercontent.com/u/99386370?v=4",
+      "profile": "https://github.com/vince-vibin",
+      "contributions": [
+        "code"
+      ]
     }
   ],
   "contributorsPerLine": 7,

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ Thanks goes to these wonderful people:
     <td align="center"><a href="https://www.reyth.dev/"><img src="https://avatars.githubusercontent.com/u/23526880?v=4" width="100px;" alt=""/><br /><sub><b>Theo REY</b></sub></a></td>
     <td align="center"><a href="https://github.com/piwi3910"><img src="https://avatars.githubusercontent.com/u/12539757?v=4" width="100px;" alt=""/><br /><sub><b>Watteel Pascal</b></sub></a></td>
     <td align="center"><a href="https://github.com/frittenlab"><img src="https://avatars.githubusercontent.com/u/29921946?v=4" width="100px;" alt=""/><br /><sub><b>simon</b></sub></a></td>
+    <td align="center"><a href="https://github.com/FernFerret"><img src="https://avatars.githubusercontent.com/u/72811?v=4" width="100px;" alt=""/><br /><sub><b>Eric</b></sub></a></td>
+    <td align="center"><a href="https://github.com/vince-vibin"><img src="https://avatars.githubusercontent.com/u/99386370?v=4" width="100px;" alt=""/><br /><sub><b>Vincent</b></sub></a></td>
   </tr>
 </table>
 

--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
 appVersion: 2022.02.1
-version: 2.7.0
+version: 2.8.0
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -2,7 +2,7 @@
 
 Installs pihole in kubernetes
 
-![Version: 2.7.0](https://img.shields.io/badge/Version-2.7.0-informational?style=flat-square) ![AppVersion: 2022.02.1](https://img.shields.io/badge/AppVersion-2022.02.1-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+![Version: 2.8.0](https://img.shields.io/badge/Version-2.8.0-informational?style=flat-square) ![AppVersion: 2022.02.1](https://img.shields.io/badge/AppVersion-2022.02.1-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-27-blue.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
@@ -234,12 +234,14 @@ The following table lists the configurable parameters of the pihole chart and th
 | regex | object | `{}` | list of blacklisted regex expressions to import during initial start of the container |
 | replicaCount | int | `1` | The number of replicas |
 | resources | object | `{}` | lines, adjust them as necessary, and remove the curly braces after 'resources:'. |
-| serviceDhcp | object | `{"annotations":{},"enabled":true,"externalTrafficPolicy":"Local","loadBalancerIP":"","loadBalancerIPv6":"","type":"NodePort"}` | Configuration for the DHCP service on port 67 |
+| serviceDhcp | object | `{"annotations":{},"enabled":true,"externalTrafficPolicy":"Local","loadBalancerIP":"","loadBalancerIPv6":"","nodePort":"","port":67,"type":"NodePort"}` | Configuration for the DHCP service on port 67 |
 | serviceDhcp.annotations | object | `{}` | Annotations for the DHCP service |
 | serviceDhcp.enabled | bool | `true` | Generate a Service resource for DHCP traffic |
 | serviceDhcp.externalTrafficPolicy | string | `"Local"` | `spec.externalTrafficPolicy` for the DHCP Service |
 | serviceDhcp.loadBalancerIP | string | `""` | A fixed `spec.loadBalancerIP` for the DHCP Service |
 | serviceDhcp.loadBalancerIPv6 | string | `""` | A fixed `spec.loadBalancerIP` for the IPv6 DHCP Service |
+| serviceDhcp.nodePort | string | `""` | Optional node port for the DHCP service |
+| serviceDhcp.port | int | `67` | The port of the DHCP service |
 | serviceDhcp.type | string | `"NodePort"` | `spec.type` for the DHCP Service |
 | serviceDns | object | `{"annotations":{},"externalTrafficPolicy":"Local","loadBalancerIP":"","loadBalancerIPv6":"","mixedService":false,"nodePort":"","port":53,"type":"NodePort"}` | Configuration for the DNS service on port 53 |
 | serviceDns.annotations | object | `{}` | Annotations for the DNS service |
@@ -250,14 +252,16 @@ The following table lists the configurable parameters of the pihole chart and th
 | serviceDns.nodePort | string | `""` | Optional node port for the DNS service |
 | serviceDns.port | int | `53` | The port of the DNS service |
 | serviceDns.type | string | `"NodePort"` | `spec.type` for the DNS Service |
-| serviceWeb | object | `{"annotations":{},"externalTrafficPolicy":"Local","http":{"enabled":true,"port":80},"https":{"enabled":true,"port":443},"loadBalancerIP":"","loadBalancerIPv6":"","type":"ClusterIP"}` | Configuration for the web interface service |
+| serviceWeb | object | `{"annotations":{},"externalTrafficPolicy":"Local","http":{"enabled":true,"nodePort":"","port":80},"https":{"enabled":true,"nodePort":"","port":443},"loadBalancerIP":"","loadBalancerIPv6":"","type":"ClusterIP"}` | Configuration for the web interface service |
 | serviceWeb.annotations | object | `{}` | Annotations for the DHCP service |
 | serviceWeb.externalTrafficPolicy | string | `"Local"` | `spec.externalTrafficPolicy` for the web interface Service |
-| serviceWeb.http | object | `{"enabled":true,"port":80}` | Configuration for the HTTP web interface listener |
+| serviceWeb.http | object | `{"enabled":true,"nodePort":"","port":80}` | Configuration for the HTTP web interface listener |
 | serviceWeb.http.enabled | bool | `true` | Generate a service for HTTP traffic |
+| serviceWeb.http.nodePort | string | `""` | Optional node port for the web HTTP service |
 | serviceWeb.http.port | int | `80` | The port of the web HTTP service |
-| serviceWeb.https | object | `{"enabled":true,"port":443}` | Configuration for the HTTPS web interface listener |
+| serviceWeb.https | object | `{"enabled":true,"nodePort":"","port":443}` | Configuration for the HTTPS web interface listener |
 | serviceWeb.https.enabled | bool | `true` | Generate a service for HTTPS traffic |
+| serviceWeb.https.nodePort | string | `""` | Optional node port for the web HTTPS service |
 | serviceWeb.https.port | int | `443` | The port of the web HTTPS service |
 | serviceWeb.loadBalancerIP | string | `""` | A fixed `spec.loadBalancerIP` for the web interface Service |
 | serviceWeb.loadBalancerIPv6 | string | `""` | A fixed `spec.loadBalancerIP` for the IPv6 web interface Service |
@@ -372,6 +376,8 @@ Thanks goes to these wonderful people:
     <td align="center"><a href="https://www.reyth.dev/"><img src="https://avatars.githubusercontent.com/u/23526880?v=4" width="100px;" alt=""/><br /><sub><b>Theo REY</b></sub></a></td>
     <td align="center"><a href="https://github.com/piwi3910"><img src="https://avatars.githubusercontent.com/u/12539757?v=4" width="100px;" alt=""/><br /><sub><b>Watteel Pascal</b></sub></a></td>
     <td align="center"><a href="https://github.com/frittenlab"><img src="https://avatars.githubusercontent.com/u/29921946?v=4" width="100px;" alt=""/><br /><sub><b>simon</b></sub></a></td>
+    <td align="center"><a href="https://github.com/FernFerret"><img src="https://avatars.githubusercontent.com/u/72811?v=4" width="100px;" alt=""/><br /><sub><b>Eric</b></sub></a></td>
+    <td align="center"><a href="https://github.com/vince-vibin"><img src="https://avatars.githubusercontent.com/u/99386370?v=4" width="100px;" alt=""/><br /><sub><b>Vincent</b></sub></a></td>
   </tr>
 </table>
 

--- a/charts/pihole/README.md.gotmpl
+++ b/charts/pihole/README.md.gotmpl
@@ -256,6 +256,8 @@ Thanks goes to these wonderful people:
     <td align="center"><a href="https://www.reyth.dev/"><img src="https://avatars.githubusercontent.com/u/23526880?v=4" width="100px;" alt=""/><br /><sub><b>Theo REY</b></sub></a></td>
     <td align="center"><a href="https://github.com/piwi3910"><img src="https://avatars.githubusercontent.com/u/12539757?v=4" width="100px;" alt=""/><br /><sub><b>Watteel Pascal</b></sub></a></td>
     <td align="center"><a href="https://github.com/frittenlab"><img src="https://avatars.githubusercontent.com/u/29921946?v=4" width="100px;" alt=""/><br /><sub><b>simon</b></sub></a></td>
+    <td align="center"><a href="https://github.com/FernFerret"><img src="https://avatars.githubusercontent.com/u/72811?v=4" width="100px;" alt=""/><br /><sub><b>Eric</b></sub></a></td>
+    <td align="center"><a href="https://github.com/vince-vibin"><img src="https://avatars.githubusercontent.com/u/99386370?v=4" width="100px;" alt=""/><br /><sub><b>Vincent</b></sub></a></td>
   </tr>
 </table>
 

--- a/charts/pihole/templates/service-dhcp.yaml
+++ b/charts/pihole/templates/service-dhcp.yaml
@@ -27,8 +27,11 @@ spec:
   externalTrafficPolicy: {{ .Values.serviceDhcp.externalTrafficPolicy }}
   {{- end }}
   ports:
-    - port: 67
+    - port: {{ .Values.serviceDhcp.port }}
       targetPort: client-udp
+      {{- if and (.Values.serviceDhcp.nodePort) (eq .Values.serviceDhcp.type "NodePort") }}
+      nodePort: {{ .Values.serviceDhcp.nodePort }}
+      {{- end }}
       protocol: UDP
       name: client-udp
   selector:

--- a/charts/pihole/templates/service-web.yaml
+++ b/charts/pihole/templates/service-web.yaml
@@ -29,12 +29,18 @@ spec:
     {{- if .Values.serviceWeb.http.enabled }}
     - port: {{ .Values.serviceWeb.http.port }}
       targetPort: http
+      {{- if and (.Values.serviceWeb.http.nodePort) (eq .Values.serviceWeb.type "NodePort") }}
+      nodePort: {{ .Values.serviceWeb.http.nodePort }}
+      {{- end }}
       protocol: TCP
       name: http
     {{- end }}
     {{- if .Values.serviceWeb.https.enabled }}
     - port: {{ .Values.serviceWeb.https.port }}
       targetPort: https
+      {{- if and (.Values.serviceWeb.https.nodePort) (eq .Values.serviceWeb.type "NodePort") }}
+      nodePort: {{ .Values.serviceWeb.https.nodePort }}
+      {{- end }}
       protocol: TCP
       name: https
     {{- end }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -69,6 +69,12 @@ serviceDhcp:
   # -- `spec.type` for the DHCP Service
   type: NodePort
 
+  # -- The port of the DHCP service
+  port: 67
+
+  # -- Optional node port for the DHCP service
+  nodePort: ""
+
   # -- `spec.externalTrafficPolicy` for the DHCP Service
   externalTrafficPolicy: Local
 
@@ -93,6 +99,9 @@ serviceWeb:
     # -- The port of the web HTTP service
     port: 80
 
+    # -- Optional node port for the web HTTP service
+    nodePort: ""
+
   # -- Configuration for the HTTPS web interface listener
   https:
     # -- Generate a service for HTTPS traffic
@@ -100,6 +109,9 @@ serviceWeb:
 
     # -- The port of the web HTTPS service
     port: 443
+
+    # -- Optional node port for the web HTTPS service
+    nodePort: ""
 
   # -- `spec.type` for the web interface Service
   type: ClusterIP

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "example": "example"
   },
   "scripts": {
-    "updateReadme": "docker run --rm --volume \"$(pwd):/helm-docs\" -u $(id -u) jnorwood/helm-docs:latest"
+    "updateReadme": "docker run --rm --volume \"$(pwd):/helm-docs\" -u $(id -u) jnorwood/helm-docs:latest",
+    "all-contributorsCheck": "all-contributors check",
+    "all-contributorsAdd": "all-contributors add"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR allows to explicitly set a `nodePort` for the dhcp and web services.

Additionally, it makes the dhcp port configurable.