### PR TITLE
Add Support for anti-affinity settings across user defined namespaces

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
 appVersion: "2023.01"
-version: 2.11.1
+version: 2.12.0
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -174,6 +174,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | antiaff.avoidRelease | string | `"pihole1"` | Here you can set the pihole release (you set in `helm install <releasename> ...`) you want to avoid |
 | antiaff.enabled | bool | `false` | set to true to enable antiaffinity (example: 2 pihole DNS in the same cluster) |
 | antiaff.strict | bool | `true` | Here you can choose between preferred or required |
+| antiaff.namespaces | '[]' | list of namespaces to include in anti-affinity settings
 | blacklist | object | `{}` | list of blacklisted domains to import during initial start of the container |
 | customVolumes.config | object | `{}` | any volume type can be used here |
 | customVolumes.enabled | bool | `false` | set this to true to enable custom volumes |

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -53,6 +53,10 @@ spec:
                   operator: In
                   values:
                   - {{ .Values.antiaff.avoidRelease }}
+        {{- if .Values.antiaff.namespaces}}
+              namespaces:
+              {{- toYaml .Values.antiaff.namespaces | nindent 14 }}
+        {{- end }}
               topologyKey: "kubernetes.io/hostname"
       {{- end }}
       {{- if .Values.podDnsConfig.enabled }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -263,6 +263,8 @@ antiaff:
   avoidRelease: pihole1
   # -- Here you can choose between preferred or required
   strict: true
+  # -- Here you can pass namespaces to be part of those inclueded in anti-affinity
+  namespaces: []
 
 doh:
   # -- set to true to enabled DNS over HTTPs via cloudflared


### PR DESCRIPTION
I run two copies of pihole using the pihole helm chart in two different namespaces. To prevent pods from either namespace landing on the same node there needs to be an option to set namespaces in scope for anti-affinity.