### PR TITLE
Adds command type liveness probe

### DIFF
--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -230,8 +230,10 @@ The following table lists the configurable parameters of the pihole chart and th
 | podDnsConfig.nameservers[1] | string | `"8.8.8.8"` |  |
 | podDnsConfig.policy | string | `"None"` |  |
 | privileged | string | `"false"` | should container run in privileged mode |
-| probes | object | `{"liveness":{"enabled":true,"failureThreshold":10,"initialDelaySeconds":60,"port":"http","scheme":"HTTP","timeoutSeconds":5},"readiness":{"enabled":true,"failureThreshold":3,"initialDelaySeconds":60,"port":"http","scheme":"HTTP","timeoutSeconds":5}}` | Probes configuration |
+| probes | object | `{"liveness":{"type": "httpGet","enabled":true,"failureThreshold":10,"initialDelaySeconds":60,"port":"http","scheme":"HTTP","timeoutSeconds":5},"readiness":{"enabled":true,"failureThreshold":3,"initialDelaySeconds":60,"port":"http","scheme":"HTTP","timeoutSeconds":5}}` | Probes configuration |
 | probes.liveness.enabled | bool | `true` | Generate a liveness probe |
+| probes.liveness.type | string | `httpGet` | Defines the type of liveness probe. (httpGet, command) |
+| probes.liveness.command | list | [] | A list of commands to execute as a liveness probe (Requires `type` to be set to `command`) |
 | probes.readiness.enabled | bool | `true` | Generate a readiness probe |
 | regex | object | `{}` | list of blacklisted regex expressions to import during initial start of the container |
 | replicaCount | int | `1` | The number of replicas |

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -189,13 +189,19 @@ spec:
             protocol: UDP
           {{- if .Values.probes.liveness.enabled }}
           livenessProbe:
+            {{- if eq .Values.probes.liveness.type "command" }}
+            exec:
+              command: {{ .Values.probes.liveness.command | required "An array of command(s) is required if 'type' is set to 'command'." | toYaml | nindent 16 }}
+            {{- else }}
             httpGet:
               path: /admin/index.php
               port: {{ .Values.probes.liveness.port }}
               scheme: {{ .Values.probes.liveness.scheme }}
+            {{- end }}
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
+            
           {{- end }}
           {{- if .Values.probes.readiness.enabled }}
           readinessProbe:

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -158,6 +158,12 @@ probes:
   # -- probes.liveness -- Configure the healthcheck for the ingress controller
   liveness:
     # -- Generate a liveness probe
+    # 'type' defaults to httpGet, can be set to 'command' to use a command type liveness probe.
+    type: httpGet
+    # command:
+    #   - /bin/bash
+    #   - -c
+    #   - /bin/true
     enabled: true
     initialDelaySeconds: 60
     failureThreshold: 10


### PR DESCRIPTION
Adds command type liveness probe. Still defaults to "httpGet".
if 'type' is set to 'command', command can be provided by `.Values.probes.liveness.command`. 