### PR TITLE
Add option to disable admin password

### DIFF
--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -178,6 +178,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | blacklist | object | `{}` | list of blacklisted domains to import during initial start of the container |
 | customVolumes.config | object | `{}` | any volume type can be used here |
 | customVolumes.enabled | bool | `false` | set this to true to enable custom volumes |
+| disablePassword | bool | `false` | set this to true to disable administrator password |
 | dnsHostPort.enabled | bool | `false` | set this to true to enable dnsHostPort |
 | dnsHostPort.port | int | `53` | default port for this pod |
 | dnsmasq.additionalHostsEntries | list | `[]` | Dnsmasq reads the /etc/hosts file to resolve ips. You can add additional entries if you like |

--- a/charts/pihole/templates/secret.yaml
+++ b/charts/pihole/templates/secret.yaml
@@ -12,6 +12,8 @@ type: Opaque
 data:
   {{- if .Values.adminPassword }}
   password: {{ .Values.adminPassword | b64enc | quote }}
+  {{- else if .Values.disablePassword }}
+  password: ""
   {{- else }}
   password: {{ randAlphaNum 40 | b64enc | quote }}
   {{- end }}


### PR DESCRIPTION
## What It Does

- Adds an option `disablePassword` to `values.yaml` that, if true, will set the Pi-hole admin password to `""` thus disabling it.

## Related Issue

Resolves: https://github.com/MoJo2600/pihole-kubernetes/issues/251
