### PR TITLE
feat: Add independent config for TCP/UDP for dnsService

### DIFF
--- a/charts/pihole/templates/service-dns-tcp.yaml
+++ b/charts/pihole/templates/service-dns-tcp.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.serviceDns.mixedService }}
+{{- if and (not .Values.serviceDns.mixedService) (.Values.serviceDns.tcp.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,9 +8,14 @@ metadata:
     chart: {{ template "pihole.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.serviceDns.annotations }}
+{{- if or .Values.serviceDns.annotations .Values.serviceDns.tcp.annotations }}
   annotations:
+{{- if .Values.serviceDns.annotations }}
 {{ toYaml .Values.serviceDns.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.serviceDns.tcp.annotations }}
+{{ toYaml .Values.serviceDns.tcp.annotations | indent 4 }}
+{{- end }}
 {{- end }}
 spec:
   type: {{ .Values.serviceDns.type }}
@@ -27,7 +32,7 @@ spec:
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
   {{- end }}
   ports:
-    - port: {{ .Values.serviceDns.port }}
+    - port: {{ .Values.serviceDns.tcp.port | default .Values.serviceDns.port }}
       targetPort: dns
       {{- if and (.Values.serviceDns.nodePort) (eq .Values.serviceDns.type "NodePort") }}
       nodePort: {{ .Values.serviceDns.nodePort }}
@@ -54,9 +59,14 @@ metadata:
     chart: {{ template "pihole.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.serviceDns.annotations }}
+{{- if or .Values.serviceDns.annotations .Values.serviceDns.tcp.annotations }}
   annotations:
+{{- if .Values.serviceDns.annotations }}
 {{ toYaml .Values.serviceDns.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.serviceDns.tcp.annotations }}
+{{ toYaml .Values.serviceDns.tcp.annotations | indent 4 }}
+{{- end }}
 {{- end }}
 spec:
   type: {{ .Values.serviceDns.type }}
@@ -70,7 +80,7 @@ spec:
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
   {{- end }}
   ports:
-    - port: {{ .Values.serviceDns.port }}
+    - port: {{ .Values.serviceDns.tcp.port | default .Values.serviceDns.port }}
       targetPort: dns
       protocol: TCP
       name: dns

--- a/charts/pihole/templates/service-dns-udp.yaml
+++ b/charts/pihole/templates/service-dns-udp.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.serviceDns.mixedService }}
+{{- if and (not .Values.serviceDns.mixedService) (.Values.serviceDns.udp.enabled) }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -8,9 +8,14 @@ metadata:
     chart: {{ template "pihole.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.serviceDns.annotations }}
+{{- if or .Values.serviceDns.annotations .Values.serviceDns.udp.annotations }}
   annotations:
+{{- if .Values.serviceDns.annotations }}
 {{ toYaml .Values.serviceDns.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.serviceDns.udp.annotations }}
+{{ toYaml .Values.serviceDns.upd.annotations | indent 4 }}
+{{- end }}
 {{- end }}
 spec:
   type: {{ .Values.serviceDns.type }}
@@ -27,7 +32,7 @@ spec:
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
   {{- end }}
   ports:
-    - port: {{ .Values.serviceDns.port }}
+    - port: {{ .Values.serviceDns.udp.port | default .Values.serviceDns.port }}
       targetPort: dns-udp
       {{- if and (.Values.serviceDns.nodePort) (eq .Values.serviceDns.type "NodePort") }}
       nodePort: {{ .Values.serviceDns.nodePort }}
@@ -48,9 +53,14 @@ metadata:
     chart: {{ template "pihole.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.serviceDns.annotations }}
+{{- if or .Values.serviceDns.annotations .Values.serviceDns.udp.annotations }}
   annotations:
+{{- if .Values.serviceDns.annotations }}
 {{ toYaml .Values.serviceDns.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.serviceDns.udp.annotations }}
+{{ toYaml .Values.serviceDns.udp.annotations | indent 4 }}
+{{- end }}
 {{- end }}
 spec:
   type: {{ .Values.serviceDns.type }}
@@ -64,7 +74,7 @@ spec:
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
   {{- end }}
   ports:
-    - port: {{ .Values.serviceDns.port }}
+    - port: {{ .Values.serviceDns.udp.port | default .Values.serviceDns.port }}
       targetPort: dns-udp
       protocol: UDP
       name: dns-udp

--- a/charts/pihole/templates/service-dns.yaml
+++ b/charts/pihole/templates/service-dns.yaml
@@ -8,9 +8,17 @@ metadata:
     chart: {{ template "pihole.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.serviceDns.annotations }}
+{{- if or (or (.Values.serviceDns.annotations) (.Values.serviceDns.udp.annotations)) (.Values.serviceDns.udp.annotations) }}
   annotations:
+{{- if .Values.serviceDns.annotations }}
 {{ toYaml .Values.serviceDns.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.serviceDns.tcp.annotations }}
+{{ toYaml .Values.serviceDns.tcp.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.serviceDns.udp.annotations }}
+{{ toYaml .Values.serviceDns.upd.annotations | indent 4 }}
+{{- end }}
 {{- end }}
 spec:
   type: {{ .Values.serviceDns.type }}
@@ -21,20 +29,24 @@ spec:
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
   {{- end }}
   ports:
-    - port: {{ .Values.serviceDns.port }}
+    {{- if (.Values.serviceDns.tcp.enabled | default true) }}
+    - port: {{ .Values.serviceDns.tcp.port | default .Values.serviceDns.port }}
       targetPort: dns
       {{- if .Values.serviceDns.nodePort }}
       nodePort: {{ .Values.serviceDns.nodePort }}
       {{- end }}
       protocol: TCP
       name: dns
-    - port: {{ .Values.serviceDns.port }}
+    {{- end }}
+    {{- if (.Values.serviceDns.udp.enabled | default true) }}
+    - port: {{ .Values.serviceDns.udp.port | default .Values.serviceDns.port }}
       targetPort: dns-udp
       {{- if and (.Values.serviceDns.nodePort) (eq .Values.serviceDns.type "NodePort") }}
       nodePort: {{ .Values.serviceDns.nodePort }}
       {{- end }}
       protocol: UDP
       name: dns-udp
+    {{- end }}
     {{- if .Values.monitoring.sidecar.enabled }}
     - port: {{ .Values.monitoring.sidecar.port }}
       targetPort: prometheus
@@ -55,9 +67,17 @@ metadata:
     chart: {{ template "pihole.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-{{- if .Values.serviceDns.annotations }}
+{{- if or (or (.Values.serviceDns.annotations) (.Values.serviceDns.udp.annotations)) (.Values.serviceDns.udp.annotations) }}
   annotations:
+{{- if .Values.serviceDns.annotations }}
 {{ toYaml .Values.serviceDns.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.serviceDns.tcp.annotations }}
+{{ toYaml .Values.serviceDns.tcp.annotations | indent 4 }}
+{{- end }}
+{{- if .Values.serviceDns.udp.annotations }}
+{{ toYaml .Values.serviceDns.upd.annotations | indent 4 }}
+{{- end }}
 {{- end }}
 spec:
   type: {{ .Values.serviceDns.type }}
@@ -71,14 +91,18 @@ spec:
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
   {{- end }}
   ports:
-    - port: {{ .Values.serviceDns.port }}
+    {{- if (.Values.serviceDns.tcp.enabled | default true) }}
+    - port: {{ .Values.serviceDns.tcp.port | default .Values.serviceDns.port }}
       targetPort: dns
       protocol: TCP
       name: dns
-    - port: {{ .Values.serviceDns.port }}
+    {{- end }}
+    {{- if (.Values.serviceDns.udp.enabled | default true) }}
+    - port: {{ .Values.serviceDns.udp.port | default .Values.serviceDns.port }}
       targetPort: dns-udp
       protocol: UDP
       name: dns-udp
+    {{- end }}
     {{- if .Values.monitoring.sidecar.enabled }}
     - port: {{ .Values.monitoring.sidecar.port }}
       targetPort: prometheus

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -44,6 +44,23 @@ serviceDns:
   # -- The port of the DNS service
   port: 53
 
+  # -- Configuration for TCP port mapping
+  tcp:
+    # -- Create a tcp port mapping
+    enabled: true
+    # -- External port to use for TCP only
+    port: 53
+    # -- Extra annotations for TCP service
+    annotations: {}
+  # -- Configuration for UDP port mapping
+  udp:
+    # -- Create a udp port mapping
+    enabled: true
+    # -- External port to use for UDP only
+    port: 53
+    # -- Extra annotations for UDP service
+    annotations: {}
+
   # -- Optional node port for the DNS service
   nodePort: ""
 


### PR DESCRIPTION
Some load balancers (AWS for example) have limitations that prevent a service from using the same port for TCP and UDP. Add ways to independently configure the port, enable/disable tcp/udp ports, and add annotations for the split services.