### PR TITLE
Only include custom CNAME file if any are set

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
 appVersion: "2023.01"
-version: 2.14.0
+version: 2.15.0
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -229,9 +229,11 @@ spec:
           - mountPath: /etc/addn-hosts
             name: custom-dnsmasq
             subPath: addn-hosts
+          {{- if .Values.dnsmasq.customCnameEntries }}
           - mountPath: /etc/dnsmasq.d/05-pihole-custom-cname.conf
             name: custom-dnsmasq
             subPath: 05-pihole-custom-cname.conf
+          {{- end }}
           {{- if .Values.adlists }}
           - mountPath: /etc/pihole/adlists.list
             name: adlists


### PR DESCRIPTION
Resolves a bug where you cannot add your own CNAMEs in the UI because of file ownership issues from mounting in the configmap as root. Here, like the other entries if we don't set any of our own it just shouldn't set the file.