### PR TITLE
feat: add support for service extraLabels

### DIFF
--- a/charts/pihole/templates/service-dhcp.yaml
+++ b/charts/pihole/templates/service-dhcp.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 {{- if .Values.serviceDhcp.extraLabels }}
-{{ toYaml .Values.servicesDhcp.extraLabels }}
+{{ toYaml .Values.servicesDhcp.extraLabels | indent 4  }}
 {{- end }}
 {{- if .Values.serviceDhcp.annotations }}
   annotations:

--- a/charts/pihole/templates/service-dhcp.yaml
+++ b/charts/pihole/templates/service-dhcp.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: {{ template "pihole.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.serviceDhcp.extraLabels }}
+{{ toYaml .Values.servicesDhcp.extraLabels }}
+{{- end }}
 {{- if .Values.serviceDhcp.annotations }}
   annotations:
 {{ toYaml .Values.serviceDhcp.annotations | indent 4 }}

--- a/charts/pihole/templates/service-dns-tcp.yaml
+++ b/charts/pihole/templates/service-dns-tcp.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 {{- if .Values.serviceDns.extraLabels }}
-{{ toYaml .Values.serviceDns.extraLabels }}
+{{ toYaml .Values.serviceDns.extraLabels | indent 4  }}
 {{- end }}
 {{- if .Values.serviceDns.annotations }}
   annotations:

--- a/charts/pihole/templates/service-dns-tcp.yaml
+++ b/charts/pihole/templates/service-dns-tcp.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: {{ template "pihole.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.serviceDns.extraLabels }}
+{{ toYaml .Values.serviceDns.extraLabels }}
+{{- end }}
 {{- if .Values.serviceDns.annotations }}
   annotations:
 {{ toYaml .Values.serviceDns.annotations | indent 4 }}

--- a/charts/pihole/templates/service-dns-udp.yaml
+++ b/charts/pihole/templates/service-dns-udp.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 {{- if .Values.serviceDns.extraLabels }}
-{{ toYaml .Values.serviceDns.extraLabels }}
+{{ toYaml .Values.serviceDns.extraLabels | indent 4  }}
 {{- end }}
 {{- if .Values.serviceDns.annotations }}
   annotations:

--- a/charts/pihole/templates/service-dns-udp.yaml
+++ b/charts/pihole/templates/service-dns-udp.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: {{ template "pihole.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.serviceDns.extraLabels }}
+{{ toYaml .Values.serviceDns.extraLabels }}
+{{- end }}
 {{- if .Values.serviceDns.annotations }}
   annotations:
 {{ toYaml .Values.serviceDns.annotations | indent 4 }}

--- a/charts/pihole/templates/service-dns.yaml
+++ b/charts/pihole/templates/service-dns.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 {{- if .Values.serviceDns.extraLabels }}
-{{ toYaml .Values.serviceDns.extraLabels }}
+{{ toYaml .Values.serviceDns.extraLabels | indent 4  }}
 {{- end }}
 {{- if .Values.serviceDns.annotations }}
   annotations:

--- a/charts/pihole/templates/service-dns.yaml
+++ b/charts/pihole/templates/service-dns.yaml
@@ -8,6 +8,9 @@ metadata:
     chart: {{ template "pihole.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.serviceDns.extraLabels }}
+{{ toYaml .Values.serviceDns.extraLabels }}
+{{- end }}
 {{- if .Values.serviceDns.annotations }}
   annotations:
 {{ toYaml .Values.serviceDns.annotations | indent 4 }}

--- a/charts/pihole/templates/service-web.yaml
+++ b/charts/pihole/templates/service-web.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 {{- if .Values.serviceWeb.extraLabels }}
-{{ toYaml .Values.serviceWeb.extraLabels }}
+{{ toYaml .Values.serviceWeb.extraLabels | indent 4 }}
 {{- end }}
 {{- if .Values.serviceWeb.annotations }}
   annotations:

--- a/charts/pihole/templates/service-web.yaml
+++ b/charts/pihole/templates/service-web.yaml
@@ -7,6 +7,9 @@ metadata:
     chart: {{ template "pihole.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+{{- if .Values.serviceWeb.extraLabels }}
+{{ toYaml .Values.serviceWeb.extraLabels }}
+{{- end }}
 {{- if .Values.serviceWeb.annotations }}
   annotations:
 {{ toYaml .Values.serviceWeb.annotations | indent 4 }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -60,6 +60,10 @@ serviceDns:
     # metallb.universe.tf/address-pool: network-services
     # metallb.universe.tf/allow-shared-ip: pihole-svc
 
+  # -- Labels for the DNS service
+  extraLabels:
+    {}
+
 # -- Configuration for the DHCP service on port 67
 serviceDhcp:
   # -- Generate a Service resource for DHCP traffic
@@ -87,6 +91,9 @@ serviceDhcp:
     {}
     # metallb.universe.tf/address-pool: network-services
     # metallb.universe.tf/allow-shared-ip: pihole-svc
+  # -- Labels for the DHCP service
+  extraLabels:
+    {}
 
 # -- Configuration for the web interface service
 serviceWeb:
@@ -128,6 +135,10 @@ serviceWeb:
     {}
     # metallb.universe.tf/address-pool: network-services
     # metallb.universe.tf/allow-shared-ip: pihole-svc
+
+  # -- Labels for the web interface service
+  extraLabels:
+    {}
 
 virtualHost: pi.hole
 


### PR DESCRIPTION
This PR adds support for adding extra labels to the services templates, these extra labels can be used to set up services integrations (e.g.: CiliumLoadBalancerIPPool can use labels to select services)