### PR TITLE
feat: add ability to disable admin password

### DIFF
--- a/charts/pihole/Chart.yaml
+++ b/charts/pihole/Chart.yaml
@@ -3,7 +3,7 @@ description: Installs pihole in kubernetes
 home: https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
 name: pihole
 appVersion: "2023.11.0"
-version: 2.20.0
+version: 2.20.1
 sources:
   - https://github.com/MoJo2600/pihole-kubernetes/tree/master/charts/pihole
   - https://pi-hole.net/

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -2,7 +2,7 @@
 
 Installs pihole in kubernetes
 
-![Version: 2.9.3](https://img.shields.io/badge/Version-2.9.3-informational?style=flat-square) ![AppVersion: 2022.09.1](https://img.shields.io/badge/AppVersion-2022.09.1-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
+![Version: 2.20.1](https://img.shields.io/badge/Version-2.20.1-informational?style=flat-square) ![AppVersion: 2023.11.0](https://img.shields.io/badge/AppVersion-2023.11.0-informational?style=flat-square) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-27-blue.svg?style=flat-square)](#contributors-)
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
@@ -166,7 +166,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | DNS1 | string | `"8.8.8.8"` | default upstream DNS 1 server to use |
 | DNS2 | string | `"8.8.4.4"` | default upstream DNS 2 server to use |
 | adlists | object | `{}` | list of adlists to import during initial start of the container |
-| admin | object | `{"existingSecret":"","passwordKey":"password"}` | Use an existing secret for the admin password. |
+| admin | object | `{"enabled":true,"existingSecret":"","passwordKey":"password"}` | Use an existing secret for the admin password. |
 | admin.enabled | bool | `true` | If set to false admin password will be disabled, adminPassword specified above and the pre-existing secret (if specified) will be ignored. |
 | admin.existingSecret | string | `""` | Specify an existing secret to use as admin password |
 | admin.passwordKey | string | `"password"` | Specify the key inside the secret to use |
@@ -174,9 +174,10 @@ The following table lists the configurable parameters of the pihole chart and th
 | affinity | object | `{}` |  |
 | antiaff.avoidRelease | string | `"pihole1"` | Here you can set the pihole release (you set in `helm install <releasename> ...`) you want to avoid |
 | antiaff.enabled | bool | `false` | set to true to enable antiaffinity (example: 2 pihole DNS in the same cluster) |
+| antiaff.namespaces | list | `[]` | Here you can pass namespaces to be part of those inclueded in anti-affinity |
 | antiaff.strict | bool | `true` | Here you can choose between preferred or required |
-| antiaff.namespaces | '[]' | list of namespaces to include in anti-affinity settings
 | blacklist | object | `{}` | list of blacklisted domains to import during initial start of the container |
+| capabilities | object | `{}` |  |
 | customVolumes.config | object | `{}` | any volume type can be used here |
 | customVolumes.enabled | bool | `false` | set this to true to enable custom volumes |
 | dnsHostPort.enabled | bool | `false` | set this to true to enable dnsHostPort |
@@ -201,6 +202,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | doh.repository | string | `"crazymax/cloudflared"` |  |
 | doh.tag | string | `"latest"` |  |
 | dualStack.enabled | bool | `false` | set this to true to enable creation of DualStack services or creation of separate IPv6 services if `serviceDns.type` is set to `"LoadBalancer"` |
+| extraContainers | list | `[]` |  |
 | extraEnvVars | object | `{}` | extraEnvironmentVars is a list of extra enviroment variables to set for pihole to use |
 | extraEnvVarsSecret | object | `{}` | extraEnvVarsSecret is a list of secrets to load in as environment variables. |
 | extraInitContainers | list | `[]` | any initContainers you might want to run before starting pihole |
@@ -227,16 +229,16 @@ The following table lists the configurable parameters of the pihole chart and th
 | persistentVolumeClaim.annotations | object | `{}` | Annotations for the `PersitentVolumeClaim` |
 | persistentVolumeClaim.enabled | bool | `false` | set to true to use pvc |
 | podAnnotations | object | `{}` | Additional annotations for pods |
+| podDisruptionBudget | object | `{"enabled":false,"minAvailable":1}` | configure a Pod Disruption Budget |
+| podDisruptionBudget.enabled | bool | `false` | set to true to enable creating the PDB |
+| podDisruptionBudget.minAvailable | int | `1` | minimum number of pods Kubernetes should try to have running at all times |
 | podDnsConfig.enabled | bool | `true` |  |
 | podDnsConfig.nameservers[0] | string | `"127.0.0.1"` |  |
 | podDnsConfig.nameservers[1] | string | `"8.8.8.8"` |  |
 | podDnsConfig.policy | string | `"None"` |  |
 | privileged | string | `"false"` | should container run in privileged mode |
-| capabilities | object | `{}` | Linux capabilities that container should run with |
-| probes | object | `{"liveness":{"type": "httpGet","enabled":true,"failureThreshold":10,"initialDelaySeconds":60,"port":"http","scheme":"HTTP","timeoutSeconds":5},"readiness":{"enabled":true,"failureThreshold":3,"initialDelaySeconds":60,"port":"http","scheme":"HTTP","timeoutSeconds":5}}` | Probes configuration |
-| probes.liveness.enabled | bool | `true` | Generate a liveness probe |
-| probes.liveness.type | string | `httpGet` | Defines the type of liveness probe. (httpGet, command) |
-| probes.liveness.command | list | [] | A list of commands to execute as a liveness probe (Requires `type` to be set to `command`) |
+| probes | object | `{"liveness":{"enabled":true,"failureThreshold":10,"initialDelaySeconds":60,"port":"http","scheme":"HTTP","timeoutSeconds":5,"type":"httpGet"},"readiness":{"enabled":true,"failureThreshold":3,"initialDelaySeconds":60,"port":"http","scheme":"HTTP","timeoutSeconds":5}}` | Probes configuration |
+| probes.liveness.type | string | `"httpGet"` | Generate a liveness probe 'type' defaults to httpGet, can be set to 'command' to use a command type liveness probe. |
 | probes.readiness.enabled | bool | `true` | Generate a readiness probe |
 | regex | object | `{}` | list of blacklisted regex expressions to import during initial start of the container |
 | replicaCount | int | `1` | The number of replicas |
@@ -400,4 +402,4 @@ Thanks goes to these wonderful people:
 This project follows the [all-contributors](https://github.com/all-contributors/all-contributors) specification. Contributions of any kind welcome!
 
 ----------------------------------------------
-Autogenerated from chart metadata using [helm-docs v1.10.0](https://github.com/norwoodj/helm-docs/releases/v1.10.0)
+Autogenerated from chart metadata using [helm-docs v1.12.0](https://github.com/norwoodj/helm-docs/releases/v1.12.0)

--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -167,6 +167,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | DNS2 | string | `"8.8.4.4"` | default upstream DNS 2 server to use |
 | adlists | object | `{}` | list of adlists to import during initial start of the container |
 | admin | object | `{"existingSecret":"","passwordKey":"password"}` | Use an existing secret for the admin password. |
+| admin.enabled | bool | `true` | If set to false admin password will be disabled, adminPassword specified above and the pre-existing secret (if specified) will be ignored. |
 | admin.existingSecret | string | `""` | Specify an existing secret to use as admin password |
 | admin.passwordKey | string | `"password"` | Specify the key inside the secret to use |
 | adminPassword | string | `"admin"` | Administrator password when not using an existing secret (see below) |

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -89,10 +89,14 @@ spec:
             - name: PIHOLE_PORT
               value: "{{ .Values.webHttp }}"
             - name: PIHOLE_PASSWORD
+              {{- if .Values.admin.enabled }}
               valueFrom:
                 secretKeyRef:
                   key: {{ .Values.admin.passwordKey | default "password" }}
                   name: {{ .Values.admin.existingSecret | default (include "pihole.password-secret" .) }}
+              {{- else }}
+              value: ""
+              {{- end }}
           resources:
 {{ toYaml .Values.monitoring.sidecar.resources | indent 12 }}
           ports:
@@ -138,10 +142,14 @@ spec:
           - name: VIRTUAL_HOST
             value: {{ .Values.virtualHost }}
           - name: WEBPASSWORD
+            {{- if .Values.admin.enabled }}
             valueFrom:
               secretKeyRef:
                 key: {{ .Values.admin.passwordKey | default "password" }}
                 name: {{ .Values.admin.existingSecret | default (include "pihole.password-secret" .) }}
+            {{- else }}
+            value: ""
+            {{- end }}
           {{- range $key, $value := .Values.extraEnvVars }}
           - name: {{ $key | quote }}
             value: {{ $value | quote }}

--- a/charts/pihole/templates/secret.yaml
+++ b/charts/pihole/templates/secret.yaml
@@ -1,4 +1,4 @@
-{{- if not .Values.admin.existingSecret }}
+{{- if and .Values.admin.enabled (not .Values.admin.existingSecret) }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -16,4 +16,3 @@ data:
   password: {{ randAlphaNum 40 | b64enc | quote }}
   {{- end }}
 {{- end }}
-

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -243,6 +243,8 @@ adminPassword: "admin"
 
 # -- Use an existing secret for the admin password.
 admin:
+  # -- If set to false admin password will be disabled, adminPassword specified above and the pre-existing secret (if specified) will be ignored.
+  enabled: true
   # -- Specify an existing secret to use as admin password
   existingSecret: ""
   # -- Specify the key inside the secret to use


### PR DESCRIPTION
Adds option `admin.enabled` (default true) which if set to false disables admin password.

Closes: #251 

Follows similar approach to taken by PR #261 but does not create secret if admin password is disabled.

From my understanding [suggestion](https://github.com/MoJo2600/pihole-kubernetes/pull/261#issuecomment-1611632540) made on PR #261 will not work as there is no way to distinguish value not set and value set to empty string in golang/helm templates. Hence why additional `admin.enabled` or `disablePassword` field is required.