### PR TITLE
fix: serviceDhcp extraLabels typo

### DIFF
--- a/charts/pihole/templates/service-dhcp.yaml
+++ b/charts/pihole/templates/service-dhcp.yaml
@@ -9,7 +9,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 {{- if .Values.serviceDhcp.extraLabels }}
-{{ toYaml .Values.servicesDhcp.extraLabels | indent 4  }}
+{{ toYaml .Values.serviceDhcp.extraLabels | indent 4  }}
 {{- end }}
 {{- if .Values.serviceDhcp.annotations }}
   annotations:


### PR DESCRIPTION
### Description of the change

Fixed a typo in the serviceDhcp.extraLabels implementation.

### Benefits

extraLabels for serviceDhcp will work without defining it twice, as serviceDhcp and servicesDhcp.

### Possible drawbacks

People who already use the faulty way will not work with this.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Title of the pull request follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/MoJo2600/pihole-kubernetes/blob/main/CONTRIBUTING.md#sign-your-work)