### PR TITLE
fix: invalid web service manifest generation

### DIFF
--- a/charts/pihole/templates/service-web.yaml
+++ b/charts/pihole/templates/service-web.yaml
@@ -1,3 +1,4 @@
+{{- if or .Values.serviceWeb.http.enabled .Values.serviceWeb.https.enabled -}}
 apiVersion: v1
 kind: Service
 metadata:
@@ -102,4 +103,5 @@ spec:
   selector:
     app: {{ template "pihole.name" . }}
     release: {{ .Release.Name }}
+{{- end }}
 {{- end }}


### PR DESCRIPTION
The `pihole-web` service is now valid when both `serviceWeb.http` and `serviceWeb.https` are disabled. Without this change, setting both of these to false will result in an invalid service manifest with an empty `spec.ports` value.

### Description of the change

This change prevents the creation of the web service manifest if both `serviceWeb.http.enabled` and `serviceWeb.https.enabled` are `false`. Setting either of these values to true (the default) will preserve existing behaviour.

### Benefits

Allows the user to not expose the pihole web service by disabling both http and https in the `serviceWeb` configuration option.

### Possible drawbacks

### Applicable issues

### Additional information

### Checklist

- [X] Title of the pull request follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/MoJo2600/pihole-kubernetes/blob/main/CONTRIBUTING.md#sign-your-work)