### PR TITLE
feat: configurable pathType for the ingress resource

### DIFF
--- a/charts/pihole/README.md
+++ b/charts/pihole/README.md
@@ -215,7 +215,7 @@ The following table lists the configurable parameters of the pihole chart and th
 | image.pullPolicy | string | `"IfNotPresent"` | the pull policy |
 | image.repository | string | `"pihole/pihole"` | the repostory to pull the image from |
 | image.tag | string | `""` | the docker tag, if left empty it will get it from the chart's appVersion |
-| ingress | object | `{"annotations":{},"enabled":false,"hosts":["chart-example.local"],"path":"/","tls":[]}` | Configuration for the Ingress |
+| ingress | object | `{"annotations":{},"enabled":false,"hosts":["chart-example.local"],"path":"/","pathType":"ImplementationSpecific","tls":[]}` | Configuration for the Ingress |
 | ingress.annotations | object | `{}` | Annotations for the ingress |
 | ingress.enabled | bool | `false` | Generate a Ingress resource |
 | maxSurge | int | `1` | The maximum number of Pods that can be created over the desired number of `ReplicaSet` during updating. |

--- a/charts/pihole/templates/ingress.yaml
+++ b/charts/pihole/templates/ingress.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.ingress.enabled -}}
 {{- $serviceName := printf "%s-%s" (include "pihole.fullname" .) "web" -}}
 {{- $ingressPath := .Values.ingress.path -}}
+{{- $pathType := .Values.ingress.pathType -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -28,7 +29,7 @@ spec:
       http:
         paths:
           - path: {{ $ingressPath }}
-            pathType: ImplementationSpecific
+            pathType: {{ $pathType }}
             backend:
               service:
                 name: {{ $serviceName }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -152,6 +152,7 @@ ingress:
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"
   path: /
+  pathType: ImplementationSpecific
   hosts:
     # virtualHost (default value is pi.hole) will be appended to the hosts
     - chart-example.local


### PR DESCRIPTION
Add a value for the ingress [pathType](https://kubernetes.io/docs/concepts/services-networking/ingress/#path-types).
I kept the default value the same to avoid any breaking changes, but I think Prefix might be a better default.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Variables are documented in the values.yaml they will be automatically added to README.md during deployment
- [X] Title of the pull request follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/MoJo2600/pihole-kubernetes/blob/main/CONTRIBUTING.md#sign-your-work)