### PR TITLE
feat: add command option to set up readiness probe.

### DIFF
--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -224,10 +224,15 @@ spec:
           {{- end }}
           {{- if .Values.probes.readiness.enabled }}
           readinessProbe:
+            {{- if eq .Values.probes.readiness.type "command" }}
+            exec:
+              command: {{ .Values.probes.readiness.command | required "An array of command(s) is required if 'type' is set to 'command'." | toYaml | nindent 16 }}
+            {{- else }}
             httpGet:
               path: /admin/index.php
               port: {{ .Values.probes.readiness.port }}
               scheme: {{ .Values.probes.readiness.scheme }}
+            {{- end }}
             initialDelaySeconds: {{ .Values.probes.readiness.initialDelaySeconds }}
             failureThreshold: {{ .Values.probes.readiness.failureThreshold }}
             timeoutSeconds: {{ .Values.probes.readiness.timeoutSeconds }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -183,14 +183,19 @@ probes:
     scheme: HTTP
   readiness:
     # -- Generate a readiness probe
+    # 'type' defaults to httpGet, can be set to 'command' to use a command type readiness probe.
+    type: httpGet
+    # command:
+    #   - /bin/bash
+    #   - -c
+    #   - /bin/true
     enabled: true
-    # -- Initial delay to wait for readiness check
+    # -- wait time before trying the readiness probe
     initialDelaySeconds: 60
-    # -- The failure threshold
-    failureThreshold: 3
-    # -- The timeout in seconds
+    # -- threshold until the probe is considered failing
+    failureThreshold: 10
+    # -- timeout in seconds
     timeoutSeconds: 5
-    # -- The port
     port: http
     scheme: HTTP
 


### PR DESCRIPTION

### Description of the change

### New Feature Addition:
* [`charts/pihole/templates/deployment.yaml`](diffhunk://#diff-30e0453700126a81330cdd1bf42c61938bbdbfb1f157121c4caf475a10d654e4R227-R235): Added support for configuring the readiness probe type as either `httpGet` or `command`. If the type is set to `command`, the readiness probe will execute a specified command.

### Configuration Updates:
* [`charts/pihole/values.yaml`](diffhunk://#diff-74c171d443ba82ea3b11a6f0d7f77e42d4b01bc2768c3ef9dbe3694acc4a064dR186-L193): Introduced a new `type` parameter for the readiness probe configuration, defaulting to `httpGet` but can be set to `command`. Updated comments to improve clarity on the purpose of each configuration parameter.] 

### Benefits

With this configuration we can avoid the problem reported in issue #301

### Possible drawbacks

With the current configuration, the default value is not changed, therefore, we do not have a breach of contract or any other problem.
Maybe it could break if someone changed the values ​​in a way I didn't foresee, but I think it's unlikely.

### Applicable issues

- fixes #301

### Additional information

I did a test and could see that the configuration worked.

<img width="916" alt="image" src="https://github.com/user-attachments/assets/569fdb56-7889-419e-b906-f26e44ade388">


### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Variables are documented in the values.yaml they will be automatically added to README.md during deployment
- [x] Title of the pull request follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] This pull request introduces a new feature to the Pi-hole Helm chart, allowing the readiness probe to be configured as either an HTTP GET request or a command execution. Additionally, it updates some of the readiness probe configuration parameters for clarity and functionality.
