### PR TITLE
feat: add custom deployment annotation option

### DIFF
--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -8,6 +8,10 @@ metadata:
     chart: {{ template "pihole.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   strategy:
@@ -222,7 +226,7 @@ spec:
             initialDelaySeconds: {{ .Values.probes.liveness.initialDelaySeconds }}
             failureThreshold: {{ .Values.probes.liveness.failureThreshold }}
             timeoutSeconds: {{ .Values.probes.liveness.timeoutSeconds }}
-            
+
           {{- end }}
           {{- if .Values.probes.readiness.enabled }}
           readinessProbe:

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -492,6 +492,10 @@ extraObjects: []
   #         }
   #       }
 
+# -- Additional annotations for the deployment
+deploymentAnnotations: {}
+  # reloader.stakater.com/auto: "true"
+
 # -- Additional annotations for pods
 podAnnotations: {}
   # Example below allows Prometheus to scape on metric port (requires pihole-exporter sidecar enabled)


### PR DESCRIPTION
TL;DR Allow the user to set a custom set of annotations for the pi-hole deployment in addition to pod-level annotations.

### Description of the change

When editing config maps (especially the whitelist), I would like to avoid having to re-run gravity via UI. The [reloader](https://github.com/stakater/Reloader) controller does this job perfectly, but requires an annotation at the deployment level, an annotation at the pod level does not work. This PR adds the option to supply an optional arbitrary set of annotations for the deployment.

### Benefits

Users can now add custom annotations to the deployment in addition to other resources.

### Applicable issues
- partly implements #219
- unfortunately does not fix #134 (if using reloader and persistent storage)

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Variables are documented in the values.yaml they will be automatically added to README.md during deployment
- [x] Title of the pull request follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/MoJo2600/pihole-kubernetes/blob/main/CONTRIBUTING.md#sign-your-work)