### PR TITLE
feat: cloudflared(doh) - add support for podmonitor and readiness

### DIFF
--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -136,6 +136,13 @@ spec:
             failureThreshold: {{ .Values.doh.probes.liveness.failureThreshold }}
             timeoutSeconds: {{ .Values.doh.probes.liveness.timeoutSeconds }}
           {{- end }}
+          {{- if .Values.doh.probes.readiness.enabled }}
+          readinessProbe:
+{{ toYaml .Values.doh.probes.readiness.probe | indent 12 }}
+            initialDelaySeconds: {{ .Values.doh.probes.readiness.initialDelaySeconds }}
+            failureThreshold: {{ .Values.doh.probes.readiness.failureThreshold }}
+            timeoutSeconds: {{ .Values.doh.probes.readiness.timeoutSeconds }}
+          {{- end }}
         {{- end }}
         - name: {{ .Chart.Name }}
           env:

--- a/charts/pihole/templates/podmonitor.yaml
+++ b/charts/pihole/templates/podmonitor.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.monitoring.podMonitor.enabled }}
+{{- if or .Values.monitoring.podMonitor.enabled .Values.doh.monitoring.podMonitor.enabled }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -16,6 +16,7 @@ metadata:
 {{- end }}
 spec:
   podMetricsEndpoints:
+{{- if .Values.monitoring.podMonitor.enabled }}
   - port: prometheus
     path: /metrics
 {{- if .Values.monitoring.podMonitor.interval }}
@@ -31,6 +32,11 @@ spec:
       {{- if .Values.monitoring.podMonitor.bearerTokenSecret.optional }}
       optional: {{ .Values.monitoring.podMonitor.bearerTokenSecret.optional }}
       {{- end }}
+{{- end }}
+{{- end }}
+{{- if .Values.doh.monitoring.podMonitor.enabled }}
+  - port: cloudflared-met
+    path: /metrics
 {{- end }}
   jobLabel: {{ template "pihole.fullname" . }}-prometheus-exporter
   namespaceSelector:

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -336,7 +336,26 @@ doh:
       failureThreshold: 10
       # -- defines the timeout in secondes for the liveness probe
       timeoutSeconds: 5
-
+    readiness:
+      # -- set to true to enable readiness probe
+      enabled: true
+      # -- customize the readiness probe
+      probe:
+        exec:
+          command:
+            - nslookup
+            - -po=5053
+            - cloudflare.com
+            - "127.0.0.1"
+      # -- defines the initial delay for the readiness probe
+      initialDelaySeconds: 60
+      # -- defines the failure threshold for the readiness probe
+      failureThreshold: 10
+      # -- defines the timeout in secondes for the readiness probe
+      timeoutSeconds: 5
+  monitoring:
+    podMonitor:
+      enabled: false
 # -- DNS MASQ settings
 dnsmasq:
   # -- Add upstream dns servers. All lines will be added to the pihole dnsmasq configuration


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

- Add readiness probe to cloudflared proxy (doh)
- Add podMonitor to cloudflared proxy (doh)

### Benefits

- Have readiness probe
- Ability to scrape metrics using podMonitor

### Possible drawbacks

<!-- Describe any known limitations with your change -->

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Variables are documented in the values.yaml they will be automatically added to README.md during deployment
- [X] Title of the pull request follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/MoJo2600/pihole-kubernetes/blob/main/CONTRIBUTING.md#sign-your-work)