### PR TITLE
CT namespace test

### DIFF
--- a/.github/workflows/lint-test.yaml
+++ b/.github/workflows/lint-test.yaml
@@ -51,3 +51,6 @@ jobs:
         if: steps.list-changed.outputs.changed == 'true'
         run: ct install --target-branch ${{ github.event.repository.default_branch }}
 
+      - name: Run chart-testing (install in namespace)
+        if: steps.list-changed.outputs.changed == 'true'
+        run: ct install --target-branch ${{ github.event.repository.default_branch }} --namespace pihole --helm-extra-set-args "monitoring.podMonitor.namespace=pihole-prom"

--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         name: 🙌 Prepare release
         id: release-please
         with:

--- a/charts/pihole/templates/configmap-adlists.yaml
+++ b/charts/pihole/templates/configmap-adlists.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "pihole.fullname" . }}-adlists
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     app: {{ template "pihole.name" . }}
     chart: {{ template "pihole.chart" . }}

--- a/charts/pihole/templates/configmap-blacklist.yaml
+++ b/charts/pihole/templates/configmap-blacklist.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "pihole.fullname" . }}-blacklist
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     app: {{ template "pihole.name" . }}
     chart: {{ template "pihole.chart" . }}

--- a/charts/pihole/templates/configmap-regex.yaml
+++ b/charts/pihole/templates/configmap-regex.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "pihole.fullname" . }}-regex
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     app: {{ template "pihole.name" . }}
     chart: {{ template "pihole.chart" . }}

--- a/charts/pihole/templates/configmap-static-dhcp.yaml
+++ b/charts/pihole/templates/configmap-static-dhcp.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "pihole.fullname" . }}-static-dhcp
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     app: {{ template "pihole.name" . }}
     chart: {{ template "pihole.chart" . }}

--- a/charts/pihole/templates/configmap-whitelist.yaml
+++ b/charts/pihole/templates/configmap-whitelist.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "pihole.fullname" . }}-whitelist
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     app: {{ template "pihole.name" . }}
     chart: {{ template "pihole.chart" . }}

--- a/charts/pihole/templates/configmap.yaml
+++ b/charts/pihole/templates/configmap.yaml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "pihole.fullname" . }}-custom-dnsmasq
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     app: {{ template "pihole.name" . }}
     chart: {{ template "pihole.chart" . }}

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -2,6 +2,9 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "pihole.fullname" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     app: {{ template "pihole.name" . }}
     app.kubernetes.io/name: {{ template "pihole.name" . }}

--- a/charts/pihole/templates/ingress.yaml
+++ b/charts/pihole/templates/ingress.yaml
@@ -6,6 +6,9 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: {{ template "pihole.fullname" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     app: {{ template "pihole.name" . }}
     chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}

--- a/charts/pihole/templates/pdb.yaml
+++ b/charts/pihole/templates/pdb.yaml
@@ -3,6 +3,9 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "pihole.fullname" . }}-pdb
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     app: {{ template "pihole.name" . }}
     chart: {{ template "pihole.chart" . }}

--- a/charts/pihole/templates/podmonitor.yaml
+++ b/charts/pihole/templates/podmonitor.yaml
@@ -11,9 +11,7 @@ metadata:
     {{- . | toYaml | nindent 4 }}
     {{- end }}
   name: {{ template "pihole.fullname" . }}-prometheus-exporter
-{{- if .Values.monitoring.podMonitor.namespace }}
-  namespace: {{ .Values.monitoring.podMonitor.namespace }}
-{{- end }}
+  namespace: {{ default "pihole-prometheus" .Values.monitoring.podMonitor.namespace }}
 spec:
   podMetricsEndpoints:
 {{- if .Values.monitoring.podMonitor.enabled }}

--- a/charts/pihole/templates/secret.yaml
+++ b/charts/pihole/templates/secret.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ template "pihole.password-secret" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     app: {{ template "pihole.name" . }}
     chart: {{ template "pihole.chart" . }}

--- a/charts/pihole/templates/service-dhcp.yaml
+++ b/charts/pihole/templates/service-dhcp.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "pihole.fullname" . }}-dhcp
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     app: {{ template "pihole.name" . }}
     app.kubernetes.io/name: {{ template "pihole.name" . }}

--- a/charts/pihole/templates/service-dns-tcp.yaml
+++ b/charts/pihole/templates/service-dns-tcp.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "pihole.fullname" . }}-dns-tcp
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     app: {{ template "pihole.name" . }}
     app.kubernetes.io/name: {{ template "pihole.name" . }}

--- a/charts/pihole/templates/service-dns-tcp.yaml
+++ b/charts/pihole/templates/service-dns-tcp.yaml
@@ -37,7 +37,7 @@ spec:
     - port: {{ .Values.serviceDns.port }}
       targetPort: dns
       {{- if and (.Values.serviceDns.nodePort) (eq .Values.serviceDns.type "NodePort") }}
-      nodePort: {{ .Values.serviceDns.nodePort }}
+      nodePort: {{ .Values.serviceDns.nodePort | add1 }}
       {{- end }}
       protocol: TCP
       name: dns

--- a/charts/pihole/templates/service-dns-udp.yaml
+++ b/charts/pihole/templates/service-dns-udp.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "pihole.fullname" . }}-dns-udp
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     app: {{ template "pihole.name" . }}
     app.kubernetes.io/name: {{ template "pihole.name" . }}

--- a/charts/pihole/templates/service-dns.yaml
+++ b/charts/pihole/templates/service-dns.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "pihole.fullname" . }}-dns
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     app: {{ template "pihole.name" . }}
     app.kubernetes.io/name: {{ template "pihole.name" . }}

--- a/charts/pihole/templates/service-dns.yaml
+++ b/charts/pihole/templates/service-dns.yaml
@@ -31,7 +31,7 @@ spec:
     - port: {{ .Values.serviceDns.port }}
       targetPort: dns
       {{- if .Values.serviceDns.nodePort }}
-      nodePort: {{ .Values.serviceDns.nodePort }}
+      nodePort: {{ .Values.serviceDns.nodePort | add1 }}
       {{- end }}
       protocol: TCP
       name: dns

--- a/charts/pihole/templates/service-web.yaml
+++ b/charts/pihole/templates/service-web.yaml
@@ -3,6 +3,9 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "pihole.fullname" . }}-web
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   labels:
     app: {{ template "pihole.name" . }}
     app.kubernetes.io/name: {{ template "pihole.name" . }}

--- a/charts/pihole/templates/tests/test-pihole-endpoint.yml
+++ b/charts/pihole/templates/tests/test-pihole-endpoint.yml
@@ -2,6 +2,9 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: "{{ .Release.Name }}-smoke-test"
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
   annotations:
     "helm.sh/hook": test
 spec:

--- a/charts/pihole/templates/volume-claim.yaml
+++ b/charts/pihole/templates/volume-claim.yaml
@@ -14,6 +14,9 @@ metadata:
     heritage: {{ .Release.Service }}
     release: {{ .Release.Name }}
   name: {{ template "pihole.fullname" . }}
+  {{- if .Release.Namespace }}
+  namespace: {{ .Release.Namespace | quote }}
+  {{- end }}
 spec:
   accessModes:
 {{ toYaml .Values.persistentVolumeClaim.accessModes | indent 4 }}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

- Added customizable namespace names. Added a test item for ct install with custom namespace.
- The DNS UDP and TCP services now listen on different nodePort numberss. Kubernetes does not allow same port for a service when listening on both TCP and UDP

### Benefits

- Allows users to set a custom namespace for PodMonitor and for pihole (they need not be the same). Not passing these values results in the default behaviour, except for PodMonitor, which now has a default namespace value of "pihole-prometheus".
- Also allows the DNS service to be installed by helm without failing, when "serviceDns.nodePort" is set for service type NodePort.

### Possible drawbacks

None that I can think of

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [ ] Variables are documented in the values.yaml they will be automatically added to README.md during deployment
- [ ] Title of the pull request follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/MoJo2600/pihole-kubernetes/blob/main/CONTRIBUTING.md#sign-your-work)