### PR TITLE
feat: Allow specifying loadBalancerClass for LoadBalancer services

### DIFF
--- a/charts/pihole/templates/service-dhcp.yaml
+++ b/charts/pihole/templates/service-dhcp.yaml
@@ -27,6 +27,9 @@ spec:
   {{- if .Values.serviceDhcp.loadBalancerIP }}
   loadBalancerIP: {{ .Values.serviceDhcp.loadBalancerIP }}
   {{- end }}
+  {{- if and (eq .Values.serviceDhcp.type "LoadBalancer") .Values.serviceDhcp.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.serviceDhcp.loadBalancerClass }}
+  {{- end }}
   {{- if or (eq .Values.serviceDhcp.type "NodePort") (eq .Values.serviceDhcp.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceDhcp.externalTrafficPolicy }}
   {{- end }}
@@ -64,6 +67,9 @@ spec:
   ipFamilyPolicy: SingleStack
   {{- if .Values.serviceDhcp.loadBalancerIPv6 }}
   loadBalancerIP: {{ .Values.serviceDhcp.loadBalancerIPv6 }}
+  {{- end }}
+  {{- if and (eq .Values.serviceDhcp.type "LoadBalancer") .Values.serviceDhcp.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.serviceDhcp.loadBalancerClass }}
   {{- end }}
   {{- if or (eq .Values.serviceDhcp.type "NodePort") (eq .Values.serviceDhcp.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceDhcp.externalTrafficPolicy }}

--- a/charts/pihole/templates/service-dns-tcp.yaml
+++ b/charts/pihole/templates/service-dns-tcp.yaml
@@ -27,6 +27,9 @@ spec:
   {{- if .Values.serviceDns.loadBalancerIP }}
   loadBalancerIP: {{ .Values.serviceDns.loadBalancerIP }}
   {{- end }}
+  {{- if and (eq .Values.serviceDns.type "LoadBalancer") .Values.serviceDns.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.serviceDns.loadBalancerClass }}
+  {{- end }}
   {{- if or (eq .Values.serviceDns.type "NodePort") (eq .Values.serviceDns.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
   {{- end }}
@@ -70,6 +73,9 @@ spec:
   ipFamilyPolicy: SingleStack
   {{- if .Values.serviceDns.loadBalancerIPv6 }}
   loadBalancerIP: {{ .Values.serviceDns.loadBalancerIPv6 }}
+  {{- end }}
+  {{- if and (eq .Values.serviceDns.type "LoadBalancer") .Values.serviceDns.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.serviceDns.loadBalancerClass }}
   {{- end }}
   {{- if or (eq .Values.serviceDns.type "NodePort") (eq .Values.serviceDns.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}

--- a/charts/pihole/templates/service-dns-udp.yaml
+++ b/charts/pihole/templates/service-dns-udp.yaml
@@ -27,6 +27,9 @@ spec:
   {{- if .Values.serviceDns.loadBalancerIP }}
   loadBalancerIP: {{ .Values.serviceDns.loadBalancerIP }}
   {{- end }}
+  {{- if and (eq .Values.serviceDns.type "LoadBalancer") .Values.serviceDns.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.serviceDns.loadBalancerClass }}
+  {{- end }}
   {{- if or (eq .Values.serviceDns.type "NodePort") (eq .Values.serviceDns.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
   {{- end }}
@@ -64,6 +67,9 @@ spec:
   ipFamilyPolicy: SingleStack
   {{- if .Values.serviceDns.loadBalancerIPv6 }}
   loadBalancerIP: {{ .Values.serviceDns.loadBalancerIPv6 }}
+  {{- end }}
+  {{- if and (eq .Values.serviceDns.type "LoadBalancer") .Values.serviceDns.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.serviceDns.loadBalancerClass }}
   {{- end }}
   {{- if or (eq .Values.serviceDns.type "NodePort") (eq .Values.serviceDns.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}

--- a/charts/pihole/templates/service-dns.yaml
+++ b/charts/pihole/templates/service-dns.yaml
@@ -21,6 +21,9 @@ spec:
   {{- if .Values.serviceDns.loadBalancerIP }}
   loadBalancerIP: {{ .Values.serviceDns.loadBalancerIP }}
   {{- end }}
+  {{- if and (eq .Values.serviceDns.type "LoadBalancer") .Values.serviceDns.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.serviceDns.loadBalancerClass }}
+  {{- end }}
   {{- if or (eq .Values.serviceDns.type "NodePort") (eq .Values.serviceDns.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}
   {{- end }}
@@ -71,6 +74,9 @@ spec:
   ipFamilyPolicy: SingleStack
   {{- if .Values.serviceDns.loadBalancerIPv6 }}
   loadBalancerIP: {{ .Values.serviceDns.loadBalancerIPv6 }}
+  {{- end }}
+  {{- if and (eq .Values.serviceDns.type "LoadBalancer") .Values.serviceDns.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.serviceDns.loadBalancerClass }}
   {{- end }}
   {{- if or (eq .Values.serviceDns.type "NodePort") (eq .Values.serviceDns.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceDns.externalTrafficPolicy }}

--- a/charts/pihole/templates/service-web.yaml
+++ b/charts/pihole/templates/service-web.yaml
@@ -27,6 +27,9 @@ spec:
   {{- if .Values.serviceWeb.loadBalancerIP }}
   loadBalancerIP: {{ .Values.serviceWeb.loadBalancerIP }}
   {{- end }}
+  {{- if and (eq .Values.serviceWeb.type "LoadBalancer") .Values.serviceWeb.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.serviceWeb.loadBalancerClass }}
+  {{- end }}
   {{- if or (eq .Values.serviceWeb.type "NodePort") (eq .Values.serviceWeb.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceWeb.externalTrafficPolicy }}
   {{- end }}
@@ -80,6 +83,9 @@ spec:
   ipFamilyPolicy: SingleStack
   {{- if .Values.serviceWeb.loadBalancerIPv6 }}
   loadBalancerIP: {{ .Values.serviceWeb.loadBalancerIPv6 }}
+  {{- end }}
+  {{- if and (eq .Values.serviceWeb.type "LoadBalancer") .Values.serviceWeb.loadBalancerClass }}
+  loadBalancerClass: {{ .Values.serviceWeb.loadBalancerClass }}
   {{- end }}
   {{- if or (eq .Values.serviceWeb.type "NodePort") (eq .Values.serviceWeb.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceWeb.externalTrafficPolicy }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -53,6 +53,8 @@ serviceDns:
   loadBalancerIP: ""
   # -- A fixed `spec.loadBalancerIP` for the IPv6 DNS Service
   loadBalancerIPv6: ""
+  # -- `spec.loadBalancerClass` for the DNS Service. Only used if type is LoadBalancer.
+  loadBalancerClass: ""
 
   # -- Annotations for the DNS service
   annotations: {}
@@ -84,6 +86,8 @@ serviceDhcp:
   loadBalancerIP: ""
   # -- A fixed `spec.loadBalancerIP` for the IPv6 DHCP Service
   loadBalancerIPv6: ""
+  # -- `spec.loadBalancerClass` for the DHCP Service. Only used if type is LoadBalancer.
+  loadBalancerClass: ""
 
   # -- Annotations for the DHCP service
   annotations: {}
@@ -127,6 +131,8 @@ serviceWeb:
   loadBalancerIP: ""
   # -- A fixed `spec.loadBalancerIP` for the IPv6 web interface Service
   loadBalancerIPv6: ""
+  # -- `spec.loadBalancerClass` for the web interface Service. Only used if type is LoadBalancer.
+  loadBalancerClass: ""
 
   # -- Annotations for the DHCP service
   annotations: {}


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

This change introduces the ability to specify `loadBalancerClass` for Kubernetes Services of type `LoadBalancer` within the Pi-hole Helm chart.

It involves:
1.  Adding a new optional `loadBalancerClass` field to the `serviceDns`, `serviceDhcp`, and `serviceWeb` sections in the `charts/pihole/values.yaml` file.
2.  Modifying the corresponding service template files (`charts/pihole/templates/service-dhcp.yaml`, `charts/pihole/templates/service-dns-tcp.yaml`, `charts/pihole/templates/service-dns-udp.yaml`, `charts/pihole/templates/service-dns.yaml`, and `charts/pihole/templates/service-web.yaml`) to include the `spec.loadBalancerClass` field in the Service manifest. This field is only rendered if the service `type` is `LoadBalancer` and a `loadBalancerClass` value is provided.

### Benefits

This change allows users to explicitly select a specific load balancer implementation if multiple are available in their Kubernetes cluster or if they need to use a non-default load balancer controller. This provides finer-grained control over how the Pi-hole services are exposed.

### Possible drawbacks

There are no known drawbacks with this change. If the `loadBalancerClass` field is not specified, the chart behaves as before, relying on the default load balancer behavior of the Kubernetes cluster.

### Applicable issues

<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes # (If this PR fixes an existing issue, please add the issue number here)

### Additional information

This feature aligns with the standard Kubernetes Service specification for `loadBalancerClass` as detailed in the [official Kubernetes documentation](https://kubernetes.io/docs/concepts/services-networking/service/#load-balancer-class).

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [X] Variables are documented in the values.yaml they will be automatically added to README.md during deployment
- [X] Title of the pull request follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/MoJo2600/pihole-kubernetes/blob/main/CONTRIBUTING.md#sign-your-work)