### PR TITLE
fix: prioritize webserver_port in extraEnvVars

### DIFF
--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -156,8 +156,10 @@ spec:
         {{- end }}
         - name: {{ .Chart.Name }}
           env:
+          {{- if not (hasKey .Values.extraEnvVars "FTLCONF_webserver_port") }}
           - name: 'FTLCONF_webserver_port'
             value: "{{ .Values.webHttp }}"
+          {{- end }}
           - name: VIRTUAL_HOST
             value: {{ .Values.virtualHost }}
           - name: FTLCONF_misc_etc_dnsmasq_d


### PR DESCRIPTION
### Description of the change

When overriding `FTLCONF_webserver_port` via the `extraEnvVars`, a duplicate key is produced. This change checks if that variable is defined in `extraEnvVars` and if so, defers to that definition.

### Benefits

Allows users to modify the currently hardcoded `FTLCONF_webserver_port` value.

### Possible drawbacks

Advanced/niche use case, could be difficult to use for beginners.

### Applicable issues

Fixes #371 

### Additional information

<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->

### Checklist

- [x] Variables are documented in the values.yaml they will be automatically added to README.md during deployment
- [x] Title of the pull request follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/MoJo2600/pihole-kubernetes/blob/main/CONTRIBUTING.md#sign-your-work)