### PR TITLE
feat: add spec.revisionHistoryLimit to deployment.yaml template

### DIFF
--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -14,6 +14,9 @@ metadata:
   {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
+  {{- if .Values.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ .Values.revisionHistoryLimit }}
+  {{- end }}
   strategy:
     type: {{ .Values.strategyType }}
     {{- if eq .Values.strategyType "RollingUpdate" }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -14,6 +14,9 @@ maxSurge: 1
 # -- The maximum number of Pods that can be unavailable during updating
 maxUnavailable: 1
 
+# -- The number of old ReplicaSets to retain to allow rollback
+revisionHistoryLimit: 10
+
 image:
   # -- the repostory to pull the image from
   repository: "pihole/pihole"


### PR DESCRIPTION
<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:
 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.
 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).
 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change
<!-- Describe the scope of your change - i.e. what the change does. -->
Added configurable `spec.revisionHistoryLimit` parameter to the Pi-hole deployment template. This change allows users to customize the number of old ReplicaSets that Kubernetes retains for rollback purposes through the `values.yaml` file, providing better control over cluster resource usage and deployment history management.

### Benefits
<!-- What benefits will be realized by the code change? -->
- **Resource optimization**: Users can reduce the number of stored ReplicaSets from the default 10 to a lower number (e.g., 3), saving cluster storage and reducing clutter
- **Customizable deployment history**: Provides flexibility to adjust revision history based on specific operational needs and rollback requirements
- **Better resource management**: Especially beneficial in resource-constrained environments where minimizing stored objects is important
- **Maintains backward compatibility**: Default behavior remains unchanged for existing deployments

### Possible drawbacks
<!-- Describe any known limitations with your change -->
- Setting the value too low (0-2) may limit rollback capabilities in case of deployment issues
- Users need to understand the implications of reducing revision history for their rollback strategy
- No validation is implemented to prevent potentially problematic values (though Kubernetes itself handles edge cases)

### Applicable issues
<!-- Enter any applicable Issues here (You can reference an issue using #) -->
- fixes #365

### Additional information
<!-- If there's anything else that's important and relevant to your pull request, mention that information here.-->
The implementation adds a new optional parameter `revisionHistoryLimit` to the values.yaml file with appropriate documentation. The deployment template conditionally includes the `spec.revisionHistoryLimit` field only when the value is explicitly set, ensuring clean YAML output and maintaining the Kubernetes default behavior when not configured.

### Checklist
<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->
- [X] Variables are documented in the values.yaml they will be automatically added to README.md during deployment
- [X] Title of the pull request follows [[conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] All commits signed off and in agreement of [[Developer Certificate of Origin (DCO)](https://github.com/MoJo2600/pihole-kubernetes/blob/main/CONTRIBUTING.md#sign-your-work)](https://github.com/MoJo2600/pihole-kubernetes/blob/main/CONTRIBUTING.md#sign-your-work)