### PR TITLE
feat: Adds sessionAffinity and sessionAffinityConfig in web service

### DIFF
--- a/charts/pihole/templates/service-web.yaml
+++ b/charts/pihole/templates/service-web.yaml
@@ -33,6 +33,13 @@ spec:
   {{- if or (eq .Values.serviceWeb.type "NodePort") (eq .Values.serviceWeb.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceWeb.externalTrafficPolicy }}
   {{- end }}
+  {{- if .Values.serviceWeb.sessionAffinity }}
+  sessionAffinity: {{ .Values.serviceWeb.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.serviceWeb.sessionAffinityConfig }}
+  sessionAffinityConfig:
+  {{- toYaml .Values.serviceWeb.sessionAffinityConfig | nindent 4 }}
+  {{- end }}
   ports:
     {{- if .Values.serviceWeb.http.enabled }}
     - port: {{ .Values.serviceWeb.http.port }}
@@ -89,6 +96,13 @@ spec:
   {{- end }}
   {{- if or (eq .Values.serviceWeb.type "NodePort") (eq .Values.serviceWeb.type "LoadBalancer") }}
   externalTrafficPolicy: {{ .Values.serviceWeb.externalTrafficPolicy }}
+  {{- end }}
+  {{- if .Values.serviceWeb.sessionAffinity }}
+  sessionAffinity: {{ .Values.serviceWeb.sessionAffinity }}
+  {{- end }}
+  {{- if .Values.serviceWeb.sessionAffinityConfig }}
+  sessionAffinityConfig:
+  {{- toYaml .Values.serviceWeb.sessionAffinityConfig | nindent 4 }}
   {{- end }}
   ports:
     {{- if .Values.serviceWeb.http.enabled }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -137,7 +137,15 @@ serviceWeb:
   # -- `spec.loadBalancerClass` for the web interface Service. Only used if type is LoadBalancer.
   loadBalancerClass: ""
 
-  # -- Annotations for the DHCP service
+  # -- Optional `.spec.sessionAffinity` for session stickness
+  # sessionAffinity: None
+  #
+  # -- Optional `.spec.sessionAffinityConfig.clientIP.timeoutSeconds` stickness timout in seconds.
+  # sessionAffinityConfig:
+  #   clientIP:
+  #     timeoutSeconds: 10800
+
+  # -- Annotations for the web service
   annotations: {}
     # metallb.universe.tf/address-pool: network-services
     # metallb.universe.tf/allow-shared-ip: pihole-svc


### PR DESCRIPTION
…late

<!--
 Before you open the request please review the following guidelines and tips to help it be more easily integrated:

 - Describe the scope of your change - i.e. what the change does.
 - Describe any known limitations with your change.
 - Please run any tests or examples that can exercise your modified code.

 Thank you for contributing! We will try to test and integrate the change as soon as we can, but be aware we have many GitHub repositories to manage and can't immediately respond to every request. There is no need to bump or check in on a pull request (it will clutter the discussion of the request).

 Also don't be worried if the request is closed or not integrated sometimes the priorities of Bitnami might not match the priorities of the pull request. Don't fret, the open source community thrives on forks and GitHub makes it easy to keep your changes in a forked repo.
 -->

### Description of the change

Adds `.spec.sessionAffinity` and `.spec.sessionAffinityConfig` in the service templating  and `values.yaml` for serviceWeb

### Benefits

Enables users to configure stickiness to web interface for clients if running multiple instances of PiHole .


- fixes #386

### Additional information

References
- [Session stickiness docs](https://kubernetes.io/docs/concepts/services-networking/service/#session-stickiness)  
- [Session affinity reference](https://kubernetes.io/docs/reference/networking/virtual-ips/#session-affinity)  
### Checklist


- [X] Variables are documented in the values.yaml they will be automatically added to README.md during deployment
- [X] Title of the pull request follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [X] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/MoJo2600/pihole-kubernetes/blob/main/CONTRIBUTING.md#sign-your-work)