### PR TITLE
feat: default container to a sane default

### DIFF
--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -37,6 +37,7 @@ spec:
         checksum.config.whitelist: {{ include (print $.Template.BasePath "/configmap-whitelist.yaml") . | sha256sum | trunc 63 }}
         checksum.config.dnsmasqConfig: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum | trunc 63 }}
         checksum.config.staticDhcpConfig: {{ include (print $.Template.BasePath "/configmap-static-dhcp.yaml") . | sha256sum | trunc 63 }}
+        kubectl.kubernetes.io/default-container: {{ .Chart.Name }}
 {{- with .Values.podAnnotations }}
 {{ toYaml . | indent 8 }}
 {{- end }}


### PR DESCRIPTION
This sets main container as the pod's default, useful when you have to work via eg. `kubectl exec`. Without it any exec command fallback to the first defined container which is almost never what an user want to do.

thank you, ciao!

- [x] Title of the pull request follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/MoJo2600/pihole-kubernetes/blob/main/CONTRIBUTING.md#sign-your-work)