### PR TITLE
feat: Make DHCP container port configurable

### DIFF
--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -232,10 +232,10 @@ spec:
           {{- if .Values.dnsHostPort.enabled }}
             hostPort: {{ .Values.dnsHostPort.port }}
           {{- end }}
-          - containerPort:  {{ .Values.webHttps }}
+          - containerPort: {{ .Values.webHttps }}
             name: https
             protocol: TCP
-          - containerPort: 67
+          - containerPort: {{ .Values.dhcpContainerPort }}
             name: client-udp
             protocol: UDP
           {{- if .Values.probes.liveness.enabled }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -455,6 +455,9 @@ webHttp: "80"
 # -- port the container should use to expose HTTPS traffic
 webHttps: "443"
 
+# -- port the container should use to expose DHCP traffic
+dhcpContainerPort: "67"
+
 # -- hostname of pod
 hostname: ""
 


### PR DESCRIPTION
### Description of the change

Make the ContainerPort of DHCP configurable

### Benefits

Use alternative ports for DHCP if needed
E.g.: 
https://thekelleys.org.uk/dnsmasq/docs/dnsmasq-man.html
```
--dhcp-alternate-port[=<server port>[,<client port>]]
(IPv4 only) Change the ports used for DHCP from the default. If this option is given alone, without arguments, it changes the ports used for DHCP from 67 and 68 to 1067 and 1068. If a single argument is given, that port number is used for the server and the port number plus one used for the client. Finally, two port numbers allows arbitrary specification of both server and client ports for DHCP.
```

### Possible drawbacks

There are no

### Applicable issues

N.A.

### Additional information

N.A.

### Checklist

<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Variables are documented in the values.yaml they will be automatically added to README.md during deployment
- [x] Title of the pull request follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/MoJo2600/pihole-kubernetes/blob/main/CONTRIBUTING.md#sign-your-work)