### PR TITLE
feat: Enhanced the charts support for web server ports

### DIFF
--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -161,7 +161,13 @@ spec:
           env:
           {{- if not (hasKey .Values.extraEnvVars "FTLCONF_webserver_port") }}
           - name: 'FTLCONF_webserver_port'
-            value: "{{ .Values.webHttp }}o,[::]:{{ .Values.webHttp }}o,{{ .Values.webHttps }}os,[::]:{{ .Values.webHttps }}os"
+            {{- if and .Values.webHttps .Values.redirectToHttps }}
+            value: "{{ .Values.webHttp }}or,{{ .Values.webHttps }}os,[::]:{{ .Values.webHttp }}or,[::]:{{ .Values.webHttps }}os"
+            {{- else if .Values.webHttps }}
+            value: "{{ .Values.webHttp }}o,{{ .Values.webHttps }}os,[::]:{{ .Values.webHttp }}o,[::]:{{ .Values.webHttps }}os"
+            {{- else }}
+            value: "{{ .Values.webHttp }}o,[::]:{{ .Values.webHttp }}o"
+            {{- end }}
           {{- end }}
           - name: VIRTUAL_HOST
             value: {{ .Values.virtualHost }}
@@ -232,9 +238,11 @@ spec:
           {{- if .Values.dnsHostPort.enabled }}
             hostPort: {{ .Values.dnsHostPort.port }}
           {{- end }}
+          {{- if .Values.webHttps }}
           - containerPort:  {{ .Values.webHttps }}
             name: https
             protocol: TCP
+          {{- end }}
           - containerPort: 67
             name: client-udp
             protocol: UDP

--- a/charts/pihole/templates/deployment.yaml
+++ b/charts/pihole/templates/deployment.yaml
@@ -161,7 +161,7 @@ spec:
           env:
           {{- if not (hasKey .Values.extraEnvVars "FTLCONF_webserver_port") }}
           - name: 'FTLCONF_webserver_port'
-            value: "{{ .Values.webHttp }}"
+            value: "{{ .Values.webHttp }}o,[::]:{{ .Values.webHttp }}o,{{ .Values.webHttps }}os,[::]:{{ .Values.webHttps }}os"
           {{- end }}
           - name: VIRTUAL_HOST
             value: {{ .Values.virtualHost }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -452,8 +452,11 @@ ftl: {}
 # -- port the container should use to expose HTTP traffic
 webHttp: "80"
 
-# -- port the container should use to expose HTTPS traffic
+# -- port the container should use to expose HTTPS traffic. When empty Pi-hole does not listen on HTTPS
 webHttps: "443"
+
+# -- set Pi-hole to redirect traffic sent to the HTTP port to HTTPS
+redirectToHttps: false
 
 # -- hostname of pod
 hostname: ""


### PR DESCRIPTION
### Description of the change
- Adds a chart value which enables automatic redirection from HTTP to HTTPS
- Reworked setting of the `FTLCONF_webserver_port` variable to match the specification of it from Pi-hole.

### Benefits
- Adds IPv6 support for the web server out of the box
- Adds automatic HTTPS redirect (when enabled)

### Possible drawbacks
/

### Applicable issues
- fixes #389 

### Additional information
/

### Checklist

- [X] Variables are documented in the values.yaml they will be automatically added to README.md during deployment
- [X] Title of the pull request follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/MoJo2600/pihole-kubernetes/blob/main/CONTRIBUTING.md#sign-your-work)