### PR TITLE
feat: add Gateway API route templates

### DIFF
--- a/charts/pihole/templates/route.yaml
+++ b/charts/pihole/templates/route.yaml
@@ -1,0 +1,46 @@
+{{- if .Values.route.enabled -}}
+{{- $serviceName := printf "%s-%s" (include "pihole.fullname" .) "web" -}}
+{{- $ingressPath := .Values.route.path -}}
+{{- $pathType := .Values.route.pathType -}}
+apiVersion: {{ .Values.route.apiVersion | default "gateway.networking.k8s.io/v1" }}
+kind: {{ .Values.route.kind | default "HTTPRoute" }}
+metadata:
+  name: {{ template "pihole.fullname" . }}
+  labels:
+    app: {{ template "pihole.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+  {{- with .Values.route.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with .Values.route.parentRefs }}
+  parentRefs:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- with .Values.route.hostnames }}
+  hostnames:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - backendRefs:
+      - name: {{ $serviceName }}
+        port: 80
+        group: ''
+        kind: Service
+        weight: 1
+      {{- with .Values.route.filters }}
+      filters:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.route.matches }}
+      matches:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.route.timeouts }}
+      timeouts:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/pihole/values.yaml
+++ b/charts/pihole/values.yaml
@@ -170,6 +170,39 @@ ingress:
   #    hosts:
   #     #- virtualHost (default value is pi.hole) will be appended to the hosts
   #      - chart-example.local
+  
+# -- Configuration for the HTTPRoute
+route:
+  # -- Generate a Gateway API route resource
+  enabled: false
+
+  # -- Set the route apiVersion
+  apiVersion: gateway.networking.k8s.io/v1
+  # -- Set the route kind
+  kind: HTTPRoute
+
+  # -- Annotations for the route
+  annotations: {}
+  # -- Labels for the route
+  labels: {}
+
+  # -- List of hostnames of the route
+  hostnames: []
+  # - chart-example.local
+
+  # -- parentsRefs definition of the route
+  parentRefs: []
+  
+  matches:
+    - path:
+        type: PathPrefix
+        value: /
+
+  # -- Timeouts define the timeouts that can be configured for an HTTP request.
+  timeouts: {}
+
+  # -- Filters that are applied to requests that match this rule
+  filters: []
 
 # -- Probes configuration
 probes:


### PR DESCRIPTION
### Description of the change

This PR adds a template for a Gateway API resource as an alternative to the already existing ingress resource. It also adds the according values to values.yaml

### Benefits
It is possible to use the Gateway API instead of only having ingress as an option. After ingress-nginx shut down lots of users are switching over

### Possible drawbacks
I cant think of any, as it is disabled by default



<!-- [Place an '[X]' (no spaces) in all applicable fields. Please remove unrelated fields.] -->

- [x] Variables are documented in the values.yaml they will be automatically added to README.md during deployment
- [x] Title of the pull request follows [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] All commits signed off and in agreement of [Developer Certificate of Origin (DCO)](https://github.com/MoJo2600/pihole-kubernetes/blob/main/CONTRIBUTING.md#sign-your-work)